### PR TITLE
Use slash character to denote ID references

### DIFF
--- a/Mage.CLI/CLI/Doc.cs
+++ b/Mage.CLI/CLI/Doc.cs
@@ -30,7 +30,7 @@ public static partial class CLICommands {
             var doc = (Document)ctx.archive.DocumentGet(docID)!;
 
             Console.WriteLine($"document {doc.hash}");
-            Console.WriteLine($"\tArchive ID: {doc.id}");
+            Console.WriteLine($"\tArchive ID: /{doc.id}");
             Console.WriteLine($"\tFile name: {doc.fileName}");
             Console.WriteLine($"\tExtension: {doc.extension}");
             Console.WriteLine($"\tIngest timestamp: {doc.ingestTimestamp}");

--- a/Mage.CLI/CLI/Taxonym.cs
+++ b/Mage.CLI/CLI/Taxonym.cs
@@ -29,18 +29,18 @@ public static partial class CLICommands {
             var taxonym = ctx.archive.TaxonymGet(taxonymID);
 
             if(taxonymID == Archive.ROOT_TAXONYM_ID){
-                Console.WriteLine($"taxonym {taxonymID}: <root>");
+                Console.WriteLine($"taxonym /{taxonymID}: <root>");
             } else {
-                Console.WriteLine($"taxonym {taxonymID}");
+                Console.WriteLine($"taxonym /{taxonymID}");
 
                 Console.WriteLine($"\tParents:");
                 var parentIDs = ctx.archive.TaxonymGetParents(taxonymID);
                 foreach(var parentID in parentIDs){
                     var parent = ctx.archive.TaxonymGet(parentID);
                     if(parentID == taxonym?.canonicalParentID){
-                        Console.WriteLine($"\t * {parent?.canonicalAlias} ({parentID})");
+                        Console.WriteLine($"\t * {parent?.canonicalAlias} (/{parentID})");
                     } else {
-                        Console.WriteLine($"\t   {parent?.canonicalAlias} ({parentID})");
+                        Console.WriteLine($"\t   {parent?.canonicalAlias} (/{parentID})");
                     }
                 }
 
@@ -131,9 +131,9 @@ public static partial class CLICommands {
 
             foreach(var taxonym in children){
                 if(taxonym?.id == Archive.ROOT_TAXONYM_ID){
-                    Console.WriteLine($"{taxonym?.id}: <root>");
+                    Console.WriteLine($"/{taxonym?.id}: <root>");
                 } else {
-                    Console.WriteLine($"{taxonym?.id}: {taxonym?.canonicalParentID}:{taxonym?.canonicalAlias}");
+                    Console.WriteLine($"/{taxonym?.id}: /{taxonym?.canonicalParentID}:{taxonym?.canonicalAlias}");
                 }
             }
 
@@ -154,9 +154,9 @@ public static partial class CLICommands {
 
             foreach(var taxonym in parents){
                 if(taxonym?.id == Archive.ROOT_TAXONYM_ID){
-                    Console.WriteLine($"{taxonym?.id}: <root>");
+                    Console.WriteLine($"/{taxonym?.id}: <root>");
                 } else {
-                    Console.WriteLine($"{taxonym?.id}: {taxonym?.canonicalParentID}:{taxonym?.canonicalAlias}");
+                    Console.WriteLine($"/{taxonym?.id}: /{taxonym?.canonicalParentID}:{taxonym?.canonicalAlias}");
                 }
             }
 

--- a/Mage.CLI/CLI/Taxonyms.cs
+++ b/Mage.CLI/CLI/Taxonyms.cs
@@ -14,13 +14,13 @@ public static partial class CLICommands {
 
             foreach(var taxonym in taxonyms){
                 if(taxonym?.id == Archive.ROOT_TAXONYM_ID){
-                    Console.WriteLine($"{taxonym?.id}: <root>");
+                    Console.WriteLine($"/{taxonym?.id}: <root>");
                 } else {
                     if(taxonym?.canonicalParentID == Archive.ROOT_TAXONYM_ID){
-                        Console.WriteLine($"{taxonym?.id}: {taxonym?.canonicalAlias}");
+                        Console.WriteLine($"/{taxonym?.id}: {taxonym?.canonicalAlias}");
                     } else {
                         var parentTaxonymName = ctx.archive.TaxonymGet((TaxonymID)taxonym?.canonicalParentID)?.canonicalAlias;
-                        Console.WriteLine($"{taxonym?.id}: {parentTaxonymName}:{taxonym?.canonicalAlias}");
+                        Console.WriteLine($"/{taxonym?.id}: {parentTaxonymName}:{taxonym?.canonicalAlias}");
                     }
                 }
             }

--- a/Mage.CLI/Engine/Archive.cs
+++ b/Mage.CLI/Engine/Archive.cs
@@ -19,7 +19,7 @@ public class Archive {
     public const string BIND_FILE_PATH = "bind";
     public const string DB_FILE_PATH = "db.sqlite";
 
-    public const int CURRENT_VERSION = 5;
+    public const int CURRENT_VERSION = 6;
     public const string IN_VIEW_NAME = "in";
     public const string OPEN_VIEW_NAME = "open";
     public const string DEFAULT_VIEW_NAME = "main";
@@ -60,7 +60,7 @@ public class Archive {
         File.WriteAllLines($"{mageDir}{BIND_FILE_PATH}", [
             $"doc=",
             $"tag=",
-            $"taxonym=1",
+            $"taxonym=/1",
             $"series=",
             $"view={DEFAULT_VIEW_NAME}"
         ]);
@@ -504,7 +504,7 @@ public class Archive {
 
     public void BindDocument(DocumentID? documentID){
         if(documentID is null) BindingSet(ObjectType.Document, "");
-        else BindingSet(ObjectType.Document, $"{documentID}");
+        else BindingSet(ObjectType.Document, $"/{documentID}");
     }
 
     public void BindView(string? viewName){

--- a/Mage.CLI/Engine/ObjectRef.cs
+++ b/Mage.CLI/Engine/ObjectRef.cs
@@ -16,12 +16,15 @@ public abstract class ObjectRef
 
     public static ObjectRef Parse(string objectRefStr)
     {
-        if ("0123456789".Contains(objectRefStr[0]))
-            return new ObjectRef_ID(int.Parse(objectRefStr));
+        // id references
+        if (objectRefStr[0] == '/')
+            return new ObjectRef_ID(int.Parse(objectRefStr[1..]));
 
+        // bound references
         if (objectRefStr == ".")
             return new ObjectRef_Binding(objectRefStr);
 
+        // view index references
         var slashIndex = objectRefStr.IndexOf('/');
         if (slashIndex != -1)
         {
@@ -33,6 +36,7 @@ public abstract class ObjectRef
             );
         }
 
+        // name references
         return new ObjectRef_Name(objectRefStr);
     }
 


### PR DESCRIPTION
Fixes #4 

Previously, the @ symbol was used for this purpose, but as it seems to cause issues in terminals, it was removed entirely. However, this itself is problematic with regard to reference string resolution, as it required names not to start with numbers. As such, ID references are now once denoted with a special character, the slash.

Old:
```bash

mage taxonym 10 # see information about taxonym with ID 10

```

New:
```bash

mage taxonym /10 # see information about taxonym with ID 10

```