### PR TITLE
Tag queries

### DIFF
--- a/Mage.CLI/CLI/Main.cs
+++ b/Mage.CLI/CLI/Main.cs
@@ -1,6 +1,7 @@
 using System.CommandLine;
 using System.Security.Cryptography.X509Certificates;
 using Mage.Engine;
+using Sprache;
 using SQLitePCL;
 
 public static partial class CLICommands {
@@ -67,14 +68,10 @@ public static partial class CLICommands {
         var com = new Command("test", "For debugging purposes.");
         com.SetHandler(() => {
             
-            ctx.archive.db.EnsureConnected();
+            var query = QueryParser.Query.Parse("(rose_lalonde AND dirk_strider) OR homestuck2");
+            Console.WriteLine(query.root);
 
-            var vriskaTaxID = (TaxonymID)ctx.archive.TaxonymFind("vriska_serket");
-            var tereziTaxID = (TaxonymID)ctx.archive.TaxonymFind("terezi_pyrope");
-            
-            var vriskaTagID = ctx.archive.db.InsertTag(new Tag(){ taxonymID = vriskaTaxID });
-            var tereziTagID = ctx.archive.db.InsertTag(new Tag(){ taxonymID = tereziTaxID });
-
+            query.GetResults(ctx.archive);
 
         });
 

--- a/Mage.CLI/Engine/QueryAST.cs
+++ b/Mage.CLI/Engine/QueryAST.cs
@@ -1,0 +1,147 @@
+namespace Mage.Engine.AST;
+
+
+
+public abstract class QueryNode {
+    public abstract string ToSQL(Archive archive);
+}
+public class QueryNodeAll : QueryNode {
+
+    public override string ToString()
+    {
+        return $"(all)";
+    }
+
+    public override string ToSQL(Archive archive){
+        return $"select DocumentID, TagID from {Query.documentTagNormalised}";
+    }
+}
+public class QueryNodeNone : QueryNode {
+    public override string ToString()
+    {
+        return $"(none)";
+    }
+
+    public override string ToSQL(Archive archive)
+    {
+        return $"select DocumentID, TagID from DocumentTag where 1=0";
+    }
+}
+public class QueryNodeTagExplicit : QueryNode {
+    public TagID tagID;
+
+    public override string ToString()
+    {
+        return $"'/{tagID}'";
+    }
+
+    public override string ToSQL(Archive archive)
+    {
+        return $"select DocumentID, TagID from DocumentTag where TagID = {tagID}";
+    }
+}
+public class QueryNodeTag : QueryNode {
+    public string tag;
+
+    public override string ToString()
+    {
+        return $"'{tag}'";
+    }
+
+    public override string ToSQL(Archive archive)
+    {
+        var tagID = (TagID)archive.TagFind(tag);
+        var antecedents = archive.TagGetAntecedents(tagID);
+        return (new QueryNodeDisjunction(){
+            args = antecedents.Prepend(tagID).Select((id) 
+                => new QueryNodeTagExplicit(){tagID = id})
+        }).ToSQL(archive);
+    }
+}
+public class QueryNodeNegation : QueryNode {
+    public QueryNode arg;
+
+    public override string ToString()
+    {
+        return $"(not {arg})";
+    }
+
+    public override string ToSQL(Archive archive){
+        var a = Query.tempTableIndex++;
+        var b = Query.tempTableIndex++;
+        return $"select DocumentID, TagID from {Query.documentTagNormalised} where DocumentID not in (select DocumentID from ({arg.ToSQL(archive)}))";
+    }
+}
+public abstract class QueryNodeJunction : QueryNode {
+    public IEnumerable<QueryNode> args;
+}
+public class QueryNodeConjunction : QueryNodeJunction {
+
+    public override string ToString()
+    {
+        return $"(and {(string.Join(' ', args))})";
+    }
+
+    public override string ToSQL(Archive archive)
+    {
+        string? lhs;
+        string? rhs;
+
+        if(args.Count() == 1){
+            return args.First().ToSQL(archive);
+        } else if(args.Count() == 2){
+            lhs = args.First().ToSQL(archive);
+            rhs = args.Skip(1).First().ToSQL(archive);
+        } else {
+            lhs = args.First().ToSQL(archive);
+            rhs = (new QueryNodeConjunction(){
+                args = args.Skip(1)
+            }).ToSQL(archive);
+        }
+        var a = Query.tempTableIndex++;
+        var b = Query.tempTableIndex++;
+        var sql = $"select t{a}.DocumentID, t{b}.TagID from ({lhs}) t{a} inner join ({rhs}) t{b} on t{a}.DocumentID = t{b}.DocumentID";
+        return sql;
+    }
+}
+public class QueryNodeDisjunction : QueryNodeJunction {
+
+    public override string ToString()
+    {
+        return $"(or {(string.Join(' ', args))})";
+    }
+
+    public override string ToSQL(Archive archive){
+        return string.Join(" union ", args.Select((l) => l.ToSQL(archive)));
+    }
+}
+
+public class Query {
+    public QueryNode root;
+    public static int tempTableIndex = 0;
+    public static string documentTagNormalised = "(select DocumentID, TagID from (select DocumentID, TagID from DocumentTag union select ID DocumentID, null from Document))";
+
+    public DocumentID[] GetResults(Archive archive){
+
+        archive.db.EnsureConnected();
+        var db = archive.db.db;
+
+        var documents = new List<DocumentID>();
+
+        var com = db.CreateCommand();
+		com.CommandText = @$"select distinct DocumentID from ({root.ToSQL(archive)});";
+		
+        //Console.WriteLine("SQL: " + com.CommandText);
+
+        var reader = com.ExecuteReader();
+        while(reader.Read()){
+            documents.Add((DocumentID)reader.GetInt32(0));
+        }
+
+        reader.Close();
+        com.Dispose();
+
+        return documents.ToArray();
+
+    }
+}

--- a/Mage.CLI/Engine/QueryEngine.cs
+++ b/Mage.CLI/Engine/QueryEngine.cs
@@ -1,0 +1,86 @@
+using Sprache;
+
+namespace Mage.Engine;
+
+public static class QueryParser {
+
+    static readonly Parser<string> Tag =
+        from head in Sprache.Parse.Lower.Once()
+        from tail in Sprache.Parse.LetterOrDigit.XOr(Sprache.Parse.Char('_')).Many()
+        select new string(head.Concat(tail).ToArray());
+
+    static readonly Parser<AST.QueryNodeTag> NodeTag =
+        from tag in Tag
+        select new AST.QueryNodeTag(){ tag = tag };
+
+    static readonly Parser<AST.QueryNodeNegation> NodeNegation =
+        from minus in Sprache.Parse.Char('-')
+        from arg in Sprache.Parse.Ref(()=>InnerNode)
+        select new AST.QueryNodeNegation(){ arg = arg };
+
+    static AST.QueryNodeJunction NodeToJunction(AST.QueryNode node) {
+        if(node is AST.QueryNodeJunction)
+            return (AST.QueryNodeJunction)node;
+        else
+            return new AST.QueryNodeDisjunction(){
+                args = [node]
+            };
+    }
+
+    static readonly Parser<AST.QueryNodeJunction> NodeJunction =
+        from inner in Sprache.Parse.ChainOperator(
+            Sprache.Parse.String("OR").Text().Token()
+            .Or(Sprache.Parse.String("AND").Text().Token()
+                .Or(Sprache.Parse.WhiteSpace.AtLeastOnce().Text())),
+            Sprache.Parse.Ref(()=>InnerNode),
+            (op, lhs, rhs) => {
+                if(op == "OR"){
+                    return (AST.QueryNode)(new AST.QueryNodeDisjunction(){ 
+                        args = [lhs, rhs]
+                    });
+                } else {
+                    return (AST.QueryNode)(new AST.QueryNodeConjunction(){ 
+                        args = [lhs, rhs]
+                    });
+                }
+            }
+        )
+        select NodeToJunction(inner);
+
+    static readonly Parser<AST.QueryNode> Group =
+        from lparen in Sprache.Parse.Char('(').Token()
+        from inner in Sprache.Parse.Ref(()=>Node)
+        from rparen in Sprache.Parse.Char(')').Token()
+        select inner;
+
+    static readonly Parser<AST.QueryNode> InnerNode =
+        Group
+        .Or(NodeNegation.Select(n => (AST.QueryNode)n))
+        .Or(NodeTag.Select(n => (AST.QueryNode)n));
+
+    static readonly Parser<AST.QueryNode> Node =
+        NodeJunction.Select(n => {
+            if(n.args.Count() == 1){
+                return n.args.First();
+            }
+            return (AST.QueryNode)n;
+        })
+        .Or(Group);
+
+    public readonly static Parser<AST.Query> Query =
+        from root in Node
+        select new AST.Query(){ root = root };
+
+    public static AST.Query Parse(string text){
+        if(text.Trim() == "")
+            return new AST.Query(){ root = new AST.QueryNodeAll() };
+
+        return Query.Parse(text);
+    }
+}
+
+public class QueryEngine {
+
+    public Archive archive;
+
+}

--- a/Mage.CLI/Mage.CLI.csproj
+++ b/Mage.CLI/Mage.CLI.csproj
@@ -8,6 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Sprache" Version="2.3.1" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="8.0.5" />
     <EmbeddedResource Include="Resources\DB\setup.sqlite.sql" />


### PR DESCRIPTION
Resolves #13 

This implements a small predicate-based query language to search for documents through their tags. The results of queries are reflected in a new view.

```bash

mage search "rose_lalonde" # tagged with rose_lalonde
mage search "-kanaya_maryam" # not tagged with dirk_strider
mage search "rose_lalonde kanaya_maryam" # tagged with both
mage search "rose_lalonde OR kanaya_maryam" # tagged with either
mage search "vriska_serket OR (rose_lalonde kanaya_maryam)" # syntactic grouping

```

Not implemented:
- XOR operator (Should be simple)
- Wildcards (Should be simple. The alias to ID translation comes before SQL generation.)
- Tag parameter searching (Awful. Awful. Awful.)