### PR TITLE
Wildcards in queries

### DIFF
--- a/Mage.CLI/Engine/QueryAST.cs
+++ b/Mage.CLI/Engine/QueryAST.cs
@@ -50,12 +50,25 @@ public class QueryNodeTag : QueryNode {
 
     public override string ToSQL(Archive archive)
     {
-        var tagID = (TagID)archive.TagFind(tag);
-        var antecedents = archive.TagGetAntecedents(tagID);
-        return (new QueryNodeDisjunction(){
-            args = antecedents.Prepend(tagID).Select((id) 
-                => new QueryNodeTagExplicit(){tagID = id})
-        }).ToSQL(archive);
+        if(tag.Contains('*')){
+
+            IEnumerable<TagID> tagIDs = archive.TagFindFuzzy(tag);
+            var antecedents = tagIDs.Select((tagID) => archive.TagGetAntecedents(tagID).Prepend(tagID)).SelectMany(x => x);
+            return (new QueryNodeDisjunction(){
+                args = antecedents.Select((id) 
+                    => new QueryNodeTagExplicit(){tagID = id})
+            }).ToSQL(archive);
+
+        } else {
+
+            var tagID = (TagID)archive.TagFind(tag);
+            var antecedents = archive.TagGetAntecedents(tagID);
+            return (new QueryNodeDisjunction(){
+                args = antecedents.Prepend(tagID).Select((id) 
+                    => new QueryNodeTagExplicit(){tagID = id})
+            }).ToSQL(archive);
+
+        }
     }
 }
 public class QueryNodeNegation : QueryNode {

--- a/Mage.CLI/Engine/QueryEngine.cs
+++ b/Mage.CLI/Engine/QueryEngine.cs
@@ -5,9 +5,7 @@ namespace Mage.Engine;
 public static class QueryParser {
 
     static readonly Parser<string> Tag =
-        from head in Sprache.Parse.Lower.Once()
-        from tail in Sprache.Parse.LetterOrDigit.XOr(Sprache.Parse.Char('_')).XOr(Sprache.Parse.Char(':')).Many()
-        select new string(head.Concat(tail).ToArray());
+        Sprache.Parse.LetterOrDigit.XOr(Sprache.Parse.Chars('_', ':', '*', '!')).Many().Text();
 
     static readonly Parser<AST.QueryNodeTag> NodeTag =
         from tag in Tag


### PR DESCRIPTION
Resolves #21 

Adds support for simple wildcards in queries and in several other places incidentally, though the latter will not entirely work given that only the first result will be used.

```bash
mage search "*_lalonde" # find all documents with tags ending with '_lalonde'
```

```bash
mage tag "*_lalonde" # view the first tag found ending with '_lalonde'
```