### PR TITLE
Use snake case in SQL

### DIFF
--- a/Mage.CLI/CLI/Doc.cs
+++ b/Mage.CLI/CLI/Doc.cs
@@ -36,7 +36,7 @@ public static partial class CLICommands {
             Console.WriteLine($"  Archive ID: /{doc.id}");
             Console.WriteLine($"  File name: {doc.fileName}");
             Console.WriteLine($"  Extension: {doc.extension}");
-            Console.WriteLine($"  Ingest timestamp: {doc.ingestTimestamp}");
+            Console.WriteLine($"  Ingest timestamp: {doc.ingestedAt}");
             Console.WriteLine($"  Comment: {(doc.comment is null ? "<none>" : doc.comment)}");
             
             var tagNames = ctx.archive.DocumentGetTags(docID).Select(tagID => ctx.archive.TagAsString(tagID));
@@ -84,12 +84,12 @@ public static partial class CLICommands {
             foreach(var tagID in tagIDs){
                 var tag = ctx.archive?.TagGet(tagID);
                 var taxonym = ctx.archive?.TaxonymGet((TaxonymID)tag?.taxonymID!);
-                var parentTaxonym = ctx.archive?.TaxonymGet((TaxonymID)taxonym?.canonicalParentID!);
+                var parentTaxonym = ctx.archive?.TaxonymGet((TaxonymID)taxonym?.canonParentID!);
 
                 if(parentTaxonym is not null)
-                    Console.WriteLine($" * {parentTaxonym?.canonicalAlias}:{taxonym?.canonicalAlias} (/{taxonym?.id})");
+                    Console.WriteLine($" * {parentTaxonym?.canonAlias}:{taxonym?.canonAlias} (/{taxonym?.id})");
                 else
-                    Console.WriteLine($" * {taxonym?.canonicalAlias} (/{taxonym?.id})");
+                    Console.WriteLine($" * {taxonym?.canonAlias} (/{taxonym?.id})");
             }
 
         }, docRefArgument);

--- a/Mage.CLI/CLI/Tag.cs
+++ b/Mage.CLI/CLI/Tag.cs
@@ -23,14 +23,14 @@ public static partial class CLICommands {
             var tagID = (TagID)ObjectRef.ResolveTag(ctx.archive!, tagRef!)!;
             var tag = ctx.archive?.TagGet(tagID);
             var taxonym = ctx.archive?.TaxonymGet((TaxonymID)tag?.taxonymID!);
-            var parentTaxonym = ctx.archive?.TaxonymGet((TaxonymID)taxonym?.canonicalParentID!);
+            var parentTaxonym = ctx.archive?.TaxonymGet((TaxonymID)taxonym?.canonParentID!);
 
             Console.WriteLine($"tag /{tagID}");
 
             if(parentTaxonym is not null)
-                Console.WriteLine($"  Taxonym: {parentTaxonym?.canonicalAlias}:{taxonym?.canonicalAlias} (/{taxonym?.id})");
+                Console.WriteLine($"  Taxonym: {parentTaxonym?.canonAlias}:{taxonym?.canonAlias} (/{taxonym?.id})");
             else
-                Console.WriteLine($"  Taxonym: {taxonym?.canonicalAlias} (/{taxonym?.id})");
+                Console.WriteLine($"  Taxonym: {taxonym?.canonAlias} (/{taxonym?.id})");
 
             Console.WriteLine($"  Document count: {ctx.archive.db.CountTagDocuments(tagID)}");
 
@@ -53,12 +53,12 @@ public static partial class CLICommands {
             foreach(var consequentID in consequentIDs){
                 var tag = ctx.archive?.TagGet(consequentID);
                 var taxonym = ctx.archive?.TaxonymGet((TaxonymID)tag?.taxonymID!);
-                var parentTaxonym = ctx.archive?.TaxonymGet((TaxonymID)taxonym?.canonicalParentID!);
+                var parentTaxonym = ctx.archive?.TaxonymGet((TaxonymID)taxonym?.canonParentID!);
 
                 if(parentTaxonym is not null)
-                    Console.WriteLine($" * {parentTaxonym?.canonicalAlias}:{taxonym?.canonicalAlias} (/{taxonym?.id})");
+                    Console.WriteLine($" * {parentTaxonym?.canonAlias}:{taxonym?.canonAlias} (/{taxonym?.id})");
                 else
-                    Console.WriteLine($" * {taxonym?.canonicalAlias} (/{taxonym?.id})");
+                    Console.WriteLine($" * {taxonym?.canonAlias} (/{taxonym?.id})");
             }
 
         }, tagRefArgument);
@@ -79,12 +79,12 @@ public static partial class CLICommands {
             foreach(var antecedentID in antecedentIDs){
                 var tag = ctx.archive?.TagGet(antecedentID);
                 var taxonym = ctx.archive?.TaxonymGet((TaxonymID)tag?.taxonymID!);
-                var parentTaxonym = ctx.archive?.TaxonymGet((TaxonymID)taxonym?.canonicalParentID!);
+                var parentTaxonym = ctx.archive?.TaxonymGet((TaxonymID)taxonym?.canonParentID!);
 
                 if(parentTaxonym is not null)
-                    Console.WriteLine($" * {parentTaxonym?.canonicalAlias}:{taxonym?.canonicalAlias} (/{taxonym?.id})");
+                    Console.WriteLine($" * {parentTaxonym?.canonAlias}:{taxonym?.canonAlias} (/{taxonym?.id})");
                 else
-                    Console.WriteLine($" * {taxonym?.canonicalAlias} (/{taxonym?.id})");
+                    Console.WriteLine($" * {taxonym?.canonAlias} (/{taxonym?.id})");
             }
 
         }, tagRefArgument);

--- a/Mage.CLI/CLI/Tags.cs
+++ b/Mage.CLI/CLI/Tags.cs
@@ -16,11 +16,11 @@ public static partial class CLICommands {
 
             foreach(var tag in tags){
                 var taxonym = ctx.archive.TaxonymGet((TaxonymID)tag?.taxonymID);
-                if(taxonym?.canonicalParentID == Archive.ROOT_TAXONYM_ID){
-                    Console.WriteLine($" * /{tag?.id}: {taxonym?.canonicalAlias}");
+                if(taxonym?.canonParentID == Archive.ROOT_TAXONYM_ID){
+                    Console.WriteLine($" * /{tag?.id}: {taxonym?.canonAlias}");
                 } else {
-                    var parentTaxonymName = ctx.archive.TaxonymGet((TaxonymID)taxonym?.canonicalParentID)?.canonicalAlias;
-                    Console.WriteLine($" * /{tag?.id}: {parentTaxonymName}:{taxonym?.canonicalAlias}");
+                    var parentTaxonymName = ctx.archive.TaxonymGet((TaxonymID)taxonym?.canonParentID)?.canonAlias;
+                    Console.WriteLine($" * /{tag?.id}: {parentTaxonymName}:{taxonym?.canonAlias}");
                 }
             }
         });

--- a/Mage.CLI/CLI/Taxonym.cs
+++ b/Mage.CLI/CLI/Taxonym.cs
@@ -37,17 +37,17 @@ public static partial class CLICommands {
                 var parentIDs = ctx.archive.TaxonymGetParents(taxonymID);
                 foreach(var parentID in parentIDs){
                     var parent = ctx.archive.TaxonymGet(parentID);
-                    if(parentID == taxonym?.canonicalParentID){
-                        Console.WriteLine($"   * {parent?.canonicalAlias} (/{parentID})");
+                    if(parentID == taxonym?.canonParentID){
+                        Console.WriteLine($"   * {parent?.canonAlias} (/{parentID})");
                     } else {
-                        Console.WriteLine($"     {parent?.canonicalAlias} (/{parentID})");
+                        Console.WriteLine($"     {parent?.canonAlias} (/{parentID})");
                     }
                 }
 
                 Console.WriteLine($"  Aliases:");
                 var aliases = ctx.archive.TaxonymGetAliases(taxonymID);
                 foreach(var alias in aliases){
-                    if(alias == taxonym?.canonicalAlias){
+                    if(alias == taxonym?.canonAlias){
                         Console.WriteLine($"   * {alias}");
                     } else {
                         Console.WriteLine($"     {alias}");
@@ -69,7 +69,7 @@ public static partial class CLICommands {
             var aliases = ctx.archive.TaxonymGetAliases(taxonymID);
 
             foreach(var alias in aliases){
-                if(alias == taxonym?.canonicalAlias){
+                if(alias == taxonym?.canonAlias){
                     Console.WriteLine($" * {alias}");
                 } else {
                     Console.WriteLine($"   {alias}");
@@ -133,7 +133,7 @@ public static partial class CLICommands {
                 if(taxonym?.id == Archive.ROOT_TAXONYM_ID){
                     Console.WriteLine($" * /{taxonym?.id}: <root>");
                 } else {
-                    Console.WriteLine($" * /{taxonym?.id}: /{taxonym?.canonicalParentID}:{taxonym?.canonicalAlias}");
+                    Console.WriteLine($" * /{taxonym?.id}: /{taxonym?.canonParentID}:{taxonym?.canonAlias}");
                 }
             }
 
@@ -156,7 +156,7 @@ public static partial class CLICommands {
                 if(taxonym?.id == Archive.ROOT_TAXONYM_ID){
                     Console.WriteLine($" * /{taxonym?.id}: <root>");
                 } else {
-                    Console.WriteLine($" * /{taxonym?.id}: /{taxonym?.canonicalParentID}:{taxonym?.canonicalAlias}");
+                    Console.WriteLine($" * /{taxonym?.id}: /{taxonym?.canonParentID}:{taxonym?.canonAlias}");
                 }
             }
 

--- a/Mage.CLI/CLI/Taxonyms.cs
+++ b/Mage.CLI/CLI/Taxonyms.cs
@@ -16,11 +16,11 @@ public static partial class CLICommands {
                 if(taxonym?.id == Archive.ROOT_TAXONYM_ID){
                     Console.WriteLine($" * /{taxonym?.id}: <root>");
                 } else {
-                    if(taxonym?.canonicalParentID == Archive.ROOT_TAXONYM_ID){
-                        Console.WriteLine($" * /{taxonym?.id}: {taxonym?.canonicalAlias}");
+                    if(taxonym?.canonParentID == Archive.ROOT_TAXONYM_ID){
+                        Console.WriteLine($" * /{taxonym?.id}: {taxonym?.canonAlias}");
                     } else {
-                        var parentTaxonymName = ctx.archive.TaxonymGet((TaxonymID)taxonym?.canonicalParentID)?.canonicalAlias;
-                        Console.WriteLine($" * /{taxonym?.id}: {parentTaxonymName}:{taxonym?.canonicalAlias}");
+                        var parentTaxonymName = ctx.archive.TaxonymGet((TaxonymID)taxonym?.canonParentID)?.canonAlias;
+                        Console.WriteLine($" * /{taxonym?.id}: {parentTaxonymName}:{taxonym?.canonAlias}");
                     }
                 }
             }

--- a/Mage.CLI/Engine/Archive.cs
+++ b/Mage.CLI/Engine/Archive.cs
@@ -152,7 +152,7 @@ public class Archive {
             hash = hash,
             fileName = fileName,
             extension = extension,
-            ingestTimestamp = DateTime.Now,
+            ingestedAt = DateTime.Now,
             comment = comment
         });
 
@@ -207,11 +207,11 @@ public class Archive {
         var taxonym = TaxonymGet(taxonymID!);
         if(taxonym?.id == ROOT_TAXONYM_ID)
             return "<root>";
-        var parentTaxonym = TaxonymGet((TaxonymID)taxonym?.canonicalParentID!);
+        var parentTaxonym = TaxonymGet((TaxonymID)taxonym?.canonParentID!);
         if(parentTaxonym is not null)
-            return $"{parentTaxonym?.canonicalAlias}:{taxonym?.canonicalAlias}";
+            return $"{parentTaxonym?.canonAlias}:{taxonym?.canonAlias}";
         else
-            return $"{taxonym?.canonicalAlias}";
+            return $"{taxonym?.canonAlias}";
     }
 
     public string TagAsString(TagID tagID){
@@ -295,46 +295,46 @@ public class Archive {
                 return [(TaxonymID)context];
             }
         }
-		
-		var target = qualifiedNameParts.First();
+        
+        var target = qualifiedNameParts.First();
 
         // replace wild cards with regex
         target = target.Replace("*", ".*");
 
-		List<TaxonymID> layerIDs = [];
-		List<(TaxonymID taxonymID, string alias)> layerAliases = [];
-		
-		var seedID = context is null ? (TaxonymID)1 : (TaxonymID)context;
-		var seedAlias = TaxonymGet(seedID)?.canonicalAlias;
-		layerIDs.Add(seedID);
-		layerAliases.Add((seedID, seedAlias));
+        List<TaxonymID> layerIDs = [];
+        List<(TaxonymID taxonymID, string alias)> layerAliases = [];
+        
+        var seedID = context is null ? (TaxonymID)1 : (TaxonymID)context;
+        var seedAlias = TaxonymGet(seedID)?.canonAlias;
+        layerIDs.Add(seedID);
+        layerAliases.Add((seedID, seedAlias));
 
         var taxonymIDs = new HashSet<TaxonymID>();
 
-		while(layerIDs.Count() > 0){
-			foreach(var (taxonymID, alias) in layerAliases){
-				if(Regex.IsMatch(alias, target)){
-					if(qualifiedNameParts.Count() == 1){
+        while(layerIDs.Count() > 0){
+            foreach(var (taxonymID, alias) in layerAliases){
+                if(Regex.IsMatch(alias, target)){
+                    if(qualifiedNameParts.Count() == 1){
                         taxonymIDs.Add(taxonymID);
-					} else {
-						taxonymIDs.UnionWith(TaxonymFindFuzzy(qualifiedNameParts.Skip(1), taxonymID));
-					}
-				}
-			}
+                    } else {
+                        taxonymIDs.UnionWith(TaxonymFindFuzzy(qualifiedNameParts.Skip(1), taxonymID));
+                    }
+                }
+            }
 
-			var idCount = layerIDs.Count();
-			var idList = String.Join(',', layerIDs.Take(idCount));
+            var idCount = layerIDs.Count();
+            var idList = String.Join(',', layerIDs.Take(idCount));
             for(int i = 0; i < idCount; i++){
                 var id = layerIDs[i];
                 layerIDs.AddRange(TaxonymGetChildren(id));
             }
-			layerIDs.RemoveRange(0, idCount);
+            layerIDs.RemoveRange(0, idCount);
             
             layerAliases.Clear();
             foreach(var id in layerIDs){
                 layerAliases.AddRange(TaxonymGetAliases(id).Select((alias) => (id, alias)));
             }
-		}
+        }
 
         return taxonymIDs.ToArray();
     }
@@ -344,8 +344,8 @@ public class Archive {
     }
     
     public TaxonymID? TaxonymFind(string qualifiedName, TaxonymID? context = null){
-		return TaxonymFind(qualifiedName.Split(':'), context);
-	}
+        return TaxonymFind(qualifiedName.Split(':'), context);
+    }
 
     public TaxonymID[] TaxonymGetChildren(TaxonymID taxonymID){
         db.EnsureConnected();
@@ -365,8 +365,8 @@ public class Archive {
     public TaxonymID? TaxonymCreate(TaxonymID parentID, string name){
         db.EnsureConnected();
         var taxonymID = db.InsertTaxonym(new Taxonym(){
-            canonicalParentID = parentID,
-            canonicalAlias = name
+            canonParentID = parentID,
+            canonAlias = name
         });
         return taxonymID;
     }

--- a/Mage.CLI/Engine/Archive.cs
+++ b/Mage.CLI/Engine/Archive.cs
@@ -20,7 +20,7 @@ public class Archive {
     public const string BIND_FILE_PATH = "bind";
     public const string DB_FILE_PATH = "db.sqlite";
 
-    public const int CURRENT_VERSION = 6;
+    public const int CURRENT_VERSION = 7;
     public const string IN_VIEW_NAME = "in";
     public const string OPEN_VIEW_NAME = "open";
     public const string DEFAULT_VIEW_NAME = "main";

--- a/Mage.CLI/Engine/DBModel.cs
+++ b/Mage.CLI/Engine/DBModel.cs
@@ -52,7 +52,7 @@ public partial class DBModel {
         var documents = new List<DocumentID>();
 
         var com = db.CreateCommand();
-		com.CommandText = $"select ID from Document {clause}";
+		com.CommandText = $"select id from document {clause}";
         com.Transaction = transaction;
 		
         var reader = com.ExecuteReader();
@@ -71,9 +71,9 @@ public partial class DBModel {
         Document? document = null;
 
         var com = db.CreateCommand();
-		com.CommandText = $"select * from Document where ID = @ID;";
+		com.CommandText = $"select * from document where id = @id;";
         com.Transaction = transaction;
-        com.Parameters.AddWithValue("ID", documentID);
+        com.Parameters.AddWithValue("id", documentID);
 		
         var reader = com.ExecuteReader();
         if(reader.Read()){
@@ -101,9 +101,9 @@ public partial class DBModel {
         string? documentHash = null;
 
         var com = db.CreateCommand();
-		com.CommandText = $"select Hash from Document where ID = @ID;";
+		com.CommandText = $"select hash from document where id = @id;";
         com.Transaction = transaction;
-        com.Parameters.AddWithValue("ID", documentID);
+        com.Parameters.AddWithValue("id", documentID);
 
         var reader = com.ExecuteReader();
         if(reader.Read()){
@@ -121,9 +121,9 @@ public partial class DBModel {
         DocumentID? documentID = null;
 
         var com = db.CreateCommand();
-		com.CommandText = $"select ID from Document where Hash = @Hash;";
+		com.CommandText = $"select id from document where hash = @hash;";
         com.Transaction = transaction;
-        com.Parameters.AddWithValue("Hash", documentHash);
+        com.Parameters.AddWithValue("hash", documentHash);
 
         var reader = com.ExecuteReader();
         if(reader.Read()){
@@ -142,7 +142,7 @@ public partial class DBModel {
         var taxonyms = new List<TaxonymID>();
 
         var com = db.CreateCommand();
-		com.CommandText = $"select ID from Taxonym {clause}";
+		com.CommandText = $"select id from taxonym {clause}";
         com.Transaction = transaction;
 		
         var reader = com.ExecuteReader();
@@ -160,9 +160,9 @@ public partial class DBModel {
         Taxonym? taxonym = null;
 
         var com = db.CreateCommand();
-        com.CommandText = $"select * from Taxonym where ID = @ID";
+        com.CommandText = $"select * from taxonym where id = @id";
         com.Transaction = transaction;
-        com.Parameters.AddWithValue("ID", taxonymID);
+        com.Parameters.AddWithValue("id", taxonymID);
 
         var reader = com.ExecuteReader();
         if(reader.Read()){
@@ -184,12 +184,12 @@ public partial class DBModel {
 
         var com = db.CreateCommand();
         com.CommandText = $@"
-            select ChildID
-            from TaxonymParent
-            where TaxonymParent.ParentID = @ParentID;
+            select child_id
+            from taxonym_parent
+            where taxonym_parent.parent_id = @parent_id;
         ";
         com.Transaction = transaction;
-        com.Parameters.AddWithValue("ParentID", taxonymID);
+        com.Parameters.AddWithValue("parent_id", taxonymID);
 
         var reader = com.ExecuteReader();
         while(reader.Read()){
@@ -207,12 +207,12 @@ public partial class DBModel {
 
         var com = db.CreateCommand();
         com.CommandText = $@"
-            select ParentID
-            from TaxonymParent
-            where TaxonymParent.ChildID = @ChildID;
+            select parent_id
+            from taxonym_parent
+            where taxonym_parent.child_id = @child_id;
         ";
         com.Transaction = transaction;
-        com.Parameters.AddWithValue("ChildID", taxonymID);
+        com.Parameters.AddWithValue("child_id", taxonymID);
 
         var reader = com.ExecuteReader();
         while(reader.Read()){
@@ -230,12 +230,12 @@ public partial class DBModel {
 
         var com = db.CreateCommand();
         com.CommandText = @"
-            select Alias
-            from TaxonymAlias
-            where TaxonymID = @TaxonymID;
+            select alias
+            from taxonym_alias
+            where taxonym_id = @taxonym_id;
         ";
         com.Transaction = transaction;
-        com.Parameters.AddWithValue("@TaxonymID", taxonymID);
+        com.Parameters.AddWithValue("@taxonym_id", taxonymID);
 
         var reader = com.ExecuteReader();
         while(reader.Read()){
@@ -253,7 +253,7 @@ public partial class DBModel {
         var tags = new List<TagID>();
 
         var com = db.CreateCommand();
-		com.CommandText = $"select ID from Tag {clause}";
+		com.CommandText = $"select id from tag {clause}";
         com.Transaction = transaction;
 		
         var reader = com.ExecuteReader();
@@ -272,11 +272,11 @@ public partial class DBModel {
         var com = db.CreateCommand();
         com.CommandText = @"
             select *
-            from Tag
-            where ID = @ID;
+            from tag
+            where id = @id;
         ";
         com.Transaction = transaction;
-        com.Parameters.AddWithValue("@ID", tagID);
+        com.Parameters.AddWithValue("@id", tagID);
 
         Tag? tag = null;
 
@@ -295,12 +295,12 @@ public partial class DBModel {
 
         var com = db.CreateCommand();
         com.CommandText = @"
-            select ID
-            from Tag
-            where TaxonymID = @TaxonymID;
+            select id
+            from tag
+            where taxonym_id = @taxonym_id;
         ";
         com.Transaction = transaction;
-        com.Parameters.AddWithValue("@TaxonymID", taxonymID);
+        com.Parameters.AddWithValue("@taxonym_id", taxonymID);
 
         var reader = com.ExecuteReader();
         if(reader.Read()){
@@ -315,12 +315,12 @@ public partial class DBModel {
 
         var com = db.CreateCommand();
 		com.CommandText = @"
-            select ConsequentID
-            from TagImplication
-            where AntecedentID = @ID;
+            select consequent_id
+            from tag_implication
+            where antecedent_id = @id;
         ";
         com.Transaction = transaction;
-        com.Parameters.AddWithValue("@ID", tagID);
+        com.Parameters.AddWithValue("@id", tagID);
 		
         var reader = com.ExecuteReader();
         while(reader.Read()){
@@ -338,12 +338,12 @@ public partial class DBModel {
 
         var com = db.CreateCommand();
 		com.CommandText = @"
-            select AntecedentID
-            from TagImplication
-            where ConsequentID = @ID;
+            select antecedent_id
+            from tag_implication
+            where consequent_id = @id;
         ";
         com.Transaction = transaction;
-        com.Parameters.AddWithValue("@ID", tagID);
+        com.Parameters.AddWithValue("@id", tagID);
 		
         var reader = com.ExecuteReader();
         while(reader.Read()){
@@ -361,12 +361,12 @@ public partial class DBModel {
 
         var com = db.CreateCommand();
 		com.CommandText = @"
-            select TagID
-            from DocumentTag
-            where DocumentID = @DocumentID;
+            select tag_id
+            from document_tag
+            where document_id = @document_id;
         ";
         com.Transaction = transaction;
-        com.Parameters.AddWithValue("@DocumentID", documentID);
+        com.Parameters.AddWithValue("@document_id", documentID);
 		
         var reader = com.ExecuteReader();
         while(reader.Read()){
@@ -382,12 +382,12 @@ public partial class DBModel {
     public int CountTagDocuments(TagID tagID, SqliteTransaction? transaction = null){
         var com = db.CreateCommand();
         com.CommandText = @"
-            select count(DocumentID)
-            from DocumentTag
-            where TagID = @TagID;
+            select count(document_id)
+            from document_tag
+            where tag_id = @tag_id;
         ";
         com.Transaction = transaction;
-        com.Parameters.AddWithValue("@TagID", tagID);
+        com.Parameters.AddWithValue("@tag_id", tagID);
 
         var reader = com.ExecuteReader();
         if(reader.Read()){
@@ -406,18 +406,18 @@ public partial class DBModel {
 
         var com = db.CreateCommand();
         com.CommandText = @"
-            insert into DocumentTag (
-                DocumentID,
-                TagID
+            insert into document_tag (
+                document_id,
+                tag_id
             )
             values (
-                @DocumentID,
-                @TagID
+                @document_id,
+                @tag_id
             );
         ";
         com.Transaction = transaction;
-        com.Parameters.AddWithValue("@DocumentID", documentID);
-        com.Parameters.AddWithValue("@TagID", tagID);
+        com.Parameters.AddWithValue("@document_id", documentID);
+        com.Parameters.AddWithValue("@tag_id", tagID);
         com.ExecuteNonQuery();
         com.Dispose();
 
@@ -427,15 +427,15 @@ public partial class DBModel {
 
         var com = db.CreateCommand();
         com.CommandText = @"
-            insert into Tag (
-                TaxonymID
+            insert into tag (
+                taxonym_id
             )
             values (
-                @TaxonymID
+                @taxonym_id
             );
         ";
         com.Transaction = transaction;
-        com.Parameters.AddWithValue("@TaxonymID", tag.taxonymID);
+        com.Parameters.AddWithValue("@taxonym_id", tag.taxonymID);
         com.ExecuteNonQuery();
         com.Dispose();
 
@@ -447,18 +447,18 @@ public partial class DBModel {
 
         var com = db.CreateCommand();
         com.CommandText = @"
-            insert into TagImplication (
-                AntecedentID,
-                ConsequentID
+            insert into tag_implication (
+                antecedent_id,
+                consequent_id
             )
             values (
-                @AntecedentID,
-                @ConsequentID
+                @antecedent_id,
+                @consequent_id
             );
         ";
         com.Transaction = transaction;
-        com.Parameters.AddWithValue("@AntecedentID", antecedentID);
-        com.Parameters.AddWithValue("@ConsequentID", consequentID);
+        com.Parameters.AddWithValue("@antecedent_id", antecedentID);
+        com.Parameters.AddWithValue("@consequent_id", consequentID);
         com.ExecuteNonQuery();
         com.Dispose();
 
@@ -468,27 +468,27 @@ public partial class DBModel {
 
         var com = db.CreateCommand();
 		com.CommandText = $@"
-            insert into Document (
-                Hash,
-                FileName,
-                Extension,
-                IngestTimestamp,
-                Comment
+            insert into document (
+                hash,
+                file_name,
+                extension,
+                ingested_at,
+                comment
             )
             values (
-                @Hash,
-                @FileName,
-                @Extension,
-                @IngestTimestamp,
-                @Comment
+                @hash,
+                @file_name,
+                @extension,
+                @ingested_at,
+                @comment
             );
         ";
         com.Transaction = transaction;
-        com.Parameters.AddWithValue("@Hash", document.hash);
-        com.Parameters.AddWithValue("@FileName", document.fileName);
-        com.Parameters.AddWithValue("@Extension", document.extension);
-        com.Parameters.AddWithValue("@IngestTimestamp", ((DateTimeOffset)(document.ingestTimestamp)).ToUnixTimeSeconds());
-        com.Parameters.AddWithValue("@Comment", document.comment is null ? System.DBNull.Value : document.comment);
+        com.Parameters.AddWithValue("@hash", document.hash);
+        com.Parameters.AddWithValue("@file_name", document.fileName);
+        com.Parameters.AddWithValue("@extension", document.extension);
+        com.Parameters.AddWithValue("@ingested_at", ((DateTimeOffset)(document.ingestTimestamp)).ToUnixTimeSeconds());
+        com.Parameters.AddWithValue("@comment", document.comment is null ? System.DBNull.Value : document.comment);
         com.ExecuteNonQuery();
         com.Dispose();
 
@@ -500,13 +500,13 @@ public partial class DBModel {
     public void InsertTaxonymAlias(TaxonymID taxonymID, string alias, SqliteTransaction? transaction = null){
         var com = db.CreateCommand();
 		com.CommandText = $@"
-            insert into TaxonymAlias
-            (TaxonymID, Alias)
-            values (@TaxonymID, @Alias);
+            insert into taxonym_alias
+            (taxonym_id, alias)
+            values (@taxonym_id, @alias);
         ";
         com.Transaction = transaction;
-        com.Parameters.AddWithValue("@TaxonymID", taxonymID);
-        com.Parameters.AddWithValue("@Alias", alias);
+        com.Parameters.AddWithValue("@taxonym_id", taxonymID);
+        com.Parameters.AddWithValue("@alias", alias);
         com.ExecuteNonQuery();
         com.Dispose();
     }
@@ -514,13 +514,13 @@ public partial class DBModel {
     public void InsertTaxonymParent(TaxonymID childID, TaxonymID parentID, SqliteTransaction? transaction = null){
         var com = db.CreateCommand();
 		com.CommandText = $@"
-            insert into TaxonymParent
-            (ChildID, ParentID)
-            values (@ChildID, @ParentID);
+            insert into taxonym_parent
+            (child_id, parent_id)
+            values (@child_id, @parent_id);
         ";
         com.Transaction = transaction;
-        com.Parameters.AddWithValue("@ChildID", childID);
-        com.Parameters.AddWithValue("@ParentID", parentID);
+        com.Parameters.AddWithValue("@child_id", childID);
+        com.Parameters.AddWithValue("@parent_id", parentID);
         com.ExecuteNonQuery();
         com.Dispose();
     }
@@ -531,13 +531,13 @@ public partial class DBModel {
 
         var com = db.CreateCommand();
         com.CommandText = $@"
-            insert into Taxonym
-            (CanonicalParentID, CanonicalAlias)
-            values (@CanonicalParentID, @CanonicalAlias)
+            insert into taxonym
+            (canon_parent_id, canon_alias)
+            values (@canon_parent_id, @canon_alias)
         ";
         com.Transaction = transaction;
-        com.Parameters.AddWithValue("@CanonicalParentID", ((object?)taxonym.canonicalParentID) ?? DBNull.Value);
-		com.Parameters.AddWithValue("@CanonicalAlias", taxonym.canonicalAlias);
+        com.Parameters.AddWithValue("@canon_parent_id", ((object?)taxonym.canonicalParentID) ?? DBNull.Value);
+		com.Parameters.AddWithValue("@canon_alias", taxonym.canonicalAlias);
 		com.ExecuteNonQuery();
 		com.Dispose();
 
@@ -562,14 +562,14 @@ public partial class DBModel {
     public void DeleteDocumentTag(DocumentID documentID, TagID tagID, SqliteTransaction? transaction = null){
         var com = db.CreateCommand();
 		com.CommandText = $@"
-            delete from DocumentTag
+            delete from document_tag
             where 
-                DocumentID = @DocumentID 
-                and TagID = @TagID;
+                document_id = @document_id 
+                and tag_id = @tag_id;
         ";
         com.Transaction = transaction;
-        com.Parameters.AddWithValue("@DocumentID", documentID);
-        com.Parameters.AddWithValue("@TagID", tagID);
+        com.Parameters.AddWithValue("@document_id", documentID);
+        com.Parameters.AddWithValue("@tag_id", tagID);
         com.ExecuteNonQuery();
         com.Dispose();
     }
@@ -577,14 +577,14 @@ public partial class DBModel {
     public void DeleteTag(TagID tagID, SqliteTransaction? transaction = null){
         var com = db.CreateCommand();
 		com.CommandText = $@"
-            delete from TagImplication
-            where AntecedentID = @ID or ConsequentID = @ID;
+            delete from tag_implication
+            where antecedent_id = @id or consequent_id = @id;
 
-            delete from Tag
-            where ID = @ID;
+            delete from tag
+            where id = @id;
         ";
         com.Transaction = transaction;
-        com.Parameters.AddWithValue("@ID", tagID);
+        com.Parameters.AddWithValue("@id", tagID);
         com.ExecuteNonQuery();
         com.Dispose();
     }
@@ -592,14 +592,14 @@ public partial class DBModel {
     public void DeleteTagImplication(TagID antecedentID, TagID consequentID, SqliteTransaction? transaction = null){
         var com = db.CreateCommand();
         com.CommandText = @"
-            delete from TagImplication
+            delete from tag_implication
             where
-                AntecedentID = @AntecedentID
-                and ConsequentID = @ConsequentID;
+                antecedent_id = @antecedent_id
+                and consequent_id = @consequent_id;
         ";
         com.Transaction = transaction;
-        com.Parameters.AddWithValue("@AntecedentID", antecedentID);
-        com.Parameters.AddWithValue("@ConsequentID", consequentID);
+        com.Parameters.AddWithValue("@antecedent_id", antecedentID);
+        com.Parameters.AddWithValue("@consequent_id", consequentID);
         com.ExecuteNonQuery();
         com.Dispose();
     }
@@ -607,18 +607,18 @@ public partial class DBModel {
     public void DeleteDocument(DocumentID documentID, SqliteTransaction? transaction = null){
         var com = db.CreateCommand();
 		com.CommandText = $@"
-            delete from Document
-            where ID = @ID;
+            delete from document
+            where id = @id;
         ";
         com.Transaction = transaction;
-        com.Parameters.AddWithValue("@ID", documentID);
+        com.Parameters.AddWithValue("@id", documentID);
         com.ExecuteNonQuery();
         com.Dispose();
     }
 
     public void DeleteAllDocuments(SqliteTransaction? transaction = null){
         var com = db.CreateCommand();
-		com.CommandText = $@"delete from Document;";
+		com.CommandText = $@"delete from document;";
         com.Transaction = transaction;
         com.ExecuteNonQuery();
         com.Dispose();
@@ -627,14 +627,14 @@ public partial class DBModel {
     public void DeleteTaxonymAlias(TaxonymID taxonymID, string alias, SqliteTransaction? transaction = null){
         var com = db.CreateCommand();
 		com.CommandText = $@"
-            delete from TaxonymAlias
+            delete from taxonym_alias
             where
-                TaxonymID = @TaxonymID
-                and Alias = @Alias;
+                taxonym_id = @taxonym_id
+                and alias = @alias;
         ";
         com.Transaction = transaction;
-        com.Parameters.AddWithValue("@TaxonymID", taxonymID);
-        com.Parameters.AddWithValue("@Alias", alias);
+        com.Parameters.AddWithValue("@taxonym_id", taxonymID);
+        com.Parameters.AddWithValue("@alias", alias);
         com.ExecuteNonQuery();
         com.Dispose();
     }
@@ -642,14 +642,14 @@ public partial class DBModel {
     public void DeleteTaxonymParent(TaxonymID childID, TaxonymID parentID, SqliteTransaction? transaction = null){
         var com = db.CreateCommand();
 		com.CommandText = $@"
-            delete from TaxonymParent
+            delete from taxonym_parent
             where
-                ChildID = @ChildID
-                and ParentID = @ParentID;
+                child_id = @child_id
+                and parent_id = @parent_id;
         ";
         com.Transaction = transaction;
-        com.Parameters.AddWithValue("@ChildID", childID);
-        com.Parameters.AddWithValue("@ParentID", parentID);
+        com.Parameters.AddWithValue("@child_id", childID);
+        com.Parameters.AddWithValue("@parent_id", parentID);
         com.ExecuteNonQuery();
         com.Dispose();
     }
@@ -659,33 +659,33 @@ public partial class DBModel {
 
         var com = db.CreateCommand();
 		com.CommandText = $@"
-            delete from Taxonym
-            where ID = @ID;
+            delete from taxonym
+            where id = @id;
         ";
         com.Transaction = transaction;
-        com.Parameters.AddWithValue("@ID", taxonymID);
+        com.Parameters.AddWithValue("@id", taxonymID);
         com.ExecuteNonQuery();
         com.Dispose();
 
         com = db.CreateCommand();
 		com.CommandText = $@"
-            delete from TaxonymAlias
-            where TaxonymID = @TaxonymID;
+            delete from taxonym_alias
+            where taxonym_id = @taxonym_id;
         ";
         com.Transaction = transaction;
-        com.Parameters.AddWithValue("@TaxonymID", taxonymID);
+        com.Parameters.AddWithValue("@taxonym_id", taxonymID);
         com.ExecuteNonQuery();
         com.Dispose();
 
         com = db.CreateCommand();
 		com.CommandText = $@"
-            delete from TaxonymParent
+            delete from taxonym_parent
             where 
-                ChildID = @TaxonymID
-                or ParentID = @TaxonymID;
+                child_id = @taxonym_id
+                or parent_id = @taxonym_id;
         ";
         com.Transaction = transaction;
-        com.Parameters.AddWithValue("@TaxonymID", taxonymID);
+        com.Parameters.AddWithValue("@taxonym_id", taxonymID);
         com.ExecuteNonQuery();
         com.Dispose();
 

--- a/Mage.CLI/Engine/DBModel.cs
+++ b/Mage.CLI/Engine/DBModel.cs
@@ -29,8 +29,8 @@ public partial class DBModel {
 
     public void RunResourceScript(string resourcePath){
         var setupCommand = db.CreateCommand();
-		setupCommand.CommandText = ResourceLoader.Load($"Resources.DB.{resourcePath}");
-		setupCommand.ExecuteNonQuery();
+        setupCommand.CommandText = ResourceLoader.Load($"Resources.DB.{resourcePath}");
+        setupCommand.ExecuteNonQuery();
         setupCommand.Dispose();
     }
 
@@ -41,8 +41,8 @@ public partial class DBModel {
 
     public long ReadLastInsertRowID(SqliteTransaction? transaction = null){
         var com = new SqliteCommand("select last_insert_rowid()", db, transaction);
-		long lastRowID = (long)com.ExecuteScalar()!;
-		com.Dispose();
+        long lastRowID = (long)com.ExecuteScalar()!;
+        com.Dispose();
 
         return lastRowID;
     }
@@ -52,9 +52,9 @@ public partial class DBModel {
         var documents = new List<DocumentID>();
 
         var com = db.CreateCommand();
-		com.CommandText = $"select id from document {clause}";
+        com.CommandText = $"select id from document {clause}";
         com.Transaction = transaction;
-		
+        
         var reader = com.ExecuteReader();
         while(reader.Read()){
             documents.Add((DocumentID)reader.GetInt32(0));
@@ -71,10 +71,10 @@ public partial class DBModel {
         Document? document = null;
 
         var com = db.CreateCommand();
-		com.CommandText = $"select * from document where id = @id;";
+        com.CommandText = $"select * from document where id = @id;";
         com.Transaction = transaction;
         com.Parameters.AddWithValue("id", documentID);
-		
+        
         var reader = com.ExecuteReader();
         if(reader.Read()){
             var ingestTimestamp = new DateTime(1970, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc);
@@ -85,7 +85,7 @@ public partial class DBModel {
                 id = documentID,
                 fileName = reader.GetString(2),
                 extension = reader.GetString(3),
-                ingestTimestamp = ingestTimestamp,
+                ingestedAt = ingestTimestamp,
                 comment = reader.IsDBNull(5) ? null : reader.GetString(5)
             };
         }
@@ -101,7 +101,7 @@ public partial class DBModel {
         string? documentHash = null;
 
         var com = db.CreateCommand();
-		com.CommandText = $"select hash from document where id = @id;";
+        com.CommandText = $"select hash from document where id = @id;";
         com.Transaction = transaction;
         com.Parameters.AddWithValue("id", documentID);
 
@@ -121,7 +121,7 @@ public partial class DBModel {
         DocumentID? documentID = null;
 
         var com = db.CreateCommand();
-		com.CommandText = $"select id from document where hash = @hash;";
+        com.CommandText = $"select id from document where hash = @hash;";
         com.Transaction = transaction;
         com.Parameters.AddWithValue("hash", documentHash);
 
@@ -142,9 +142,9 @@ public partial class DBModel {
         var taxonyms = new List<TaxonymID>();
 
         var com = db.CreateCommand();
-		com.CommandText = $"select id from taxonym {clause}";
+        com.CommandText = $"select id from taxonym {clause}";
         com.Transaction = transaction;
-		
+        
         var reader = com.ExecuteReader();
         while(reader.Read()){
             taxonyms.Add((TaxonymID)reader.GetInt32(0));
@@ -168,8 +168,8 @@ public partial class DBModel {
         if(reader.Read()){
             taxonym = new Taxonym(){
                 id = taxonymID,
-                canonicalParentID = reader.IsDBNull(1) ? null : (TaxonymID)reader.GetInt32(1),
-                canonicalAlias = reader.GetString(2)
+                canonParentID = reader.IsDBNull(1) ? null : (TaxonymID)reader.GetInt32(1),
+                canonAlias = reader.GetString(2)
             };
         }
 
@@ -253,9 +253,9 @@ public partial class DBModel {
         var tags = new List<TagID>();
 
         var com = db.CreateCommand();
-		com.CommandText = $"select id from tag {clause}";
+        com.CommandText = $"select id from tag {clause}";
         com.Transaction = transaction;
-		
+        
         var reader = com.ExecuteReader();
         while(reader.Read()){
             tags.Add((TagID)reader.GetInt32(0));
@@ -314,14 +314,14 @@ public partial class DBModel {
         var consequents = new List<TagID>();
 
         var com = db.CreateCommand();
-		com.CommandText = @"
+        com.CommandText = @"
             select consequent_id
             from tag_implication
             where antecedent_id = @id;
         ";
         com.Transaction = transaction;
         com.Parameters.AddWithValue("@id", tagID);
-		
+        
         var reader = com.ExecuteReader();
         while(reader.Read()){
             consequents.Add((TagID)reader.GetInt32(0));
@@ -337,14 +337,14 @@ public partial class DBModel {
         var antecedents = new List<TagID>();
 
         var com = db.CreateCommand();
-		com.CommandText = @"
+        com.CommandText = @"
             select antecedent_id
             from tag_implication
             where consequent_id = @id;
         ";
         com.Transaction = transaction;
         com.Parameters.AddWithValue("@id", tagID);
-		
+        
         var reader = com.ExecuteReader();
         while(reader.Read()){
             antecedents.Add((TagID)reader.GetInt32(0));
@@ -360,14 +360,14 @@ public partial class DBModel {
         var tagIDs = new List<TagID>();
 
         var com = db.CreateCommand();
-		com.CommandText = @"
+        com.CommandText = @"
             select tag_id
             from document_tag
             where document_id = @document_id;
         ";
         com.Transaction = transaction;
         com.Parameters.AddWithValue("@document_id", documentID);
-		
+        
         var reader = com.ExecuteReader();
         while(reader.Read()){
             tagIDs.Add((TagID)reader.GetInt32(0));
@@ -467,7 +467,7 @@ public partial class DBModel {
     public DocumentID InsertDocument(Document document, SqliteTransaction? transaction = null){
 
         var com = db.CreateCommand();
-		com.CommandText = $@"
+        com.CommandText = $@"
             insert into document (
                 hash,
                 file_name,
@@ -487,7 +487,7 @@ public partial class DBModel {
         com.Parameters.AddWithValue("@hash", document.hash);
         com.Parameters.AddWithValue("@file_name", document.fileName);
         com.Parameters.AddWithValue("@extension", document.extension);
-        com.Parameters.AddWithValue("@ingested_at", ((DateTimeOffset)(document.ingestTimestamp)).ToUnixTimeSeconds());
+        com.Parameters.AddWithValue("@ingested_at", ((DateTimeOffset)(document.ingestedAt)).ToUnixTimeSeconds());
         com.Parameters.AddWithValue("@comment", document.comment is null ? System.DBNull.Value : document.comment);
         com.ExecuteNonQuery();
         com.Dispose();
@@ -499,7 +499,7 @@ public partial class DBModel {
 
     public void InsertTaxonymAlias(TaxonymID taxonymID, string alias, SqliteTransaction? transaction = null){
         var com = db.CreateCommand();
-		com.CommandText = $@"
+        com.CommandText = $@"
             insert into taxonym_alias
             (taxonym_id, alias)
             values (@taxonym_id, @alias);
@@ -513,7 +513,7 @@ public partial class DBModel {
 
     public void InsertTaxonymParent(TaxonymID childID, TaxonymID parentID, SqliteTransaction? transaction = null){
         var com = db.CreateCommand();
-		com.CommandText = $@"
+        com.CommandText = $@"
             insert into taxonym_parent
             (child_id, parent_id)
             values (@child_id, @parent_id);
@@ -536,16 +536,16 @@ public partial class DBModel {
             values (@canon_parent_id, @canon_alias)
         ";
         com.Transaction = transaction;
-        com.Parameters.AddWithValue("@canon_parent_id", ((object?)taxonym.canonicalParentID) ?? DBNull.Value);
-		com.Parameters.AddWithValue("@canon_alias", taxonym.canonicalAlias);
-		com.ExecuteNonQuery();
-		com.Dispose();
+        com.Parameters.AddWithValue("@canon_parent_id", ((object?)taxonym.canonParentID) ?? DBNull.Value);
+        com.Parameters.AddWithValue("@canon_alias", taxonym.canonAlias);
+        com.ExecuteNonQuery();
+        com.Dispose();
 
         var taxonymID = (TaxonymID)ReadLastInsertRowID(transaction);
 
-        InsertTaxonymAlias(taxonymID, taxonym.canonicalAlias, transaction);
-        if(taxonym.canonicalParentID is not null)
-            InsertTaxonymParent(taxonymID, (TaxonymID)taxonym.canonicalParentID, transaction);
+        InsertTaxonymAlias(taxonymID, taxonym.canonAlias, transaction);
+        if(taxonym.canonParentID is not null)
+            InsertTaxonymParent(taxonymID, (TaxonymID)taxonym.canonParentID, transaction);
 
         transaction.Commit();
         transaction.Dispose();
@@ -561,7 +561,7 @@ public partial class DBModel {
 
     public void DeleteDocumentTag(DocumentID documentID, TagID tagID, SqliteTransaction? transaction = null){
         var com = db.CreateCommand();
-		com.CommandText = $@"
+        com.CommandText = $@"
             delete from document_tag
             where 
                 document_id = @document_id 
@@ -576,7 +576,7 @@ public partial class DBModel {
 
     public void DeleteTag(TagID tagID, SqliteTransaction? transaction = null){
         var com = db.CreateCommand();
-		com.CommandText = $@"
+        com.CommandText = $@"
             delete from tag_implication
             where antecedent_id = @id or consequent_id = @id;
 
@@ -606,7 +606,7 @@ public partial class DBModel {
 
     public void DeleteDocument(DocumentID documentID, SqliteTransaction? transaction = null){
         var com = db.CreateCommand();
-		com.CommandText = $@"
+        com.CommandText = $@"
             delete from document
             where id = @id;
         ";
@@ -618,7 +618,7 @@ public partial class DBModel {
 
     public void DeleteAllDocuments(SqliteTransaction? transaction = null){
         var com = db.CreateCommand();
-		com.CommandText = $@"delete from document;";
+        com.CommandText = $@"delete from document;";
         com.Transaction = transaction;
         com.ExecuteNonQuery();
         com.Dispose();
@@ -626,7 +626,7 @@ public partial class DBModel {
 
     public void DeleteTaxonymAlias(TaxonymID taxonymID, string alias, SqliteTransaction? transaction = null){
         var com = db.CreateCommand();
-		com.CommandText = $@"
+        com.CommandText = $@"
             delete from taxonym_alias
             where
                 taxonym_id = @taxonym_id
@@ -641,7 +641,7 @@ public partial class DBModel {
 
     public void DeleteTaxonymParent(TaxonymID childID, TaxonymID parentID, SqliteTransaction? transaction = null){
         var com = db.CreateCommand();
-		com.CommandText = $@"
+        com.CommandText = $@"
             delete from taxonym_parent
             where
                 child_id = @child_id
@@ -658,7 +658,7 @@ public partial class DBModel {
         transaction = db.BeginTransaction();
 
         var com = db.CreateCommand();
-		com.CommandText = $@"
+        com.CommandText = $@"
             delete from taxonym
             where id = @id;
         ";
@@ -668,7 +668,7 @@ public partial class DBModel {
         com.Dispose();
 
         com = db.CreateCommand();
-		com.CommandText = $@"
+        com.CommandText = $@"
             delete from taxonym_alias
             where taxonym_id = @taxonym_id;
         ";
@@ -678,7 +678,7 @@ public partial class DBModel {
         com.Dispose();
 
         com = db.CreateCommand();
-		com.CommandText = $@"
+        com.CommandText = $@"
             delete from taxonym_parent
             where 
                 child_id = @taxonym_id

--- a/Mage.CLI/Engine/Document.cs
+++ b/Mage.CLI/Engine/Document.cs
@@ -5,6 +5,6 @@ public struct Document {
     public DocumentID? id;
     public string fileName;
     public string extension;
-    public DateTime ingestTimestamp;
+    public DateTime ingestedAt;
     public string? comment;
 }

--- a/Mage.CLI/Engine/QueryAST.cs
+++ b/Mage.CLI/Engine/QueryAST.cs
@@ -24,7 +24,7 @@ public class QueryNodeNone : QueryNode {
 
     public override string ToSQL(Archive archive)
     {
-        return $"select ID from Document where 1=0";
+        return $"select id from document where 1=0";
     }
 }
 public class QueryNodeTagExplicit : QueryNode {
@@ -37,7 +37,7 @@ public class QueryNodeTagExplicit : QueryNode {
 
     public override string ToSQL(Archive archive)
     {
-        return $"select DocumentID ID from DocumentTag where TagID = {tagID}";
+        return $"select document_id id from document_tag where tag_id = {tagID}";
     }
 }
 public class QueryNodeTag : QueryNode {
@@ -82,7 +82,7 @@ public class QueryNodeNegation : QueryNode {
     public override string ToSQL(Archive archive){
         var a = Query.tempTableIndex++;
         var b = Query.tempTableIndex++;
-        return $"{Query.documentTagNormalised} where ID not in (select ID from ({arg.ToSQL(archive)}))";
+        return $"{Query.documentTagNormalised} where id not in (select id from ({arg.ToSQL(archive)}))";
     }
 }
 public abstract class QueryNodeJunction : QueryNode {
@@ -132,7 +132,7 @@ public class QueryNodeDisjunction : QueryNodeJunction {
 public class Query {
     public QueryNode root;
     public static int tempTableIndex = 0;
-    public static string documentTagNormalised = "select ID from Document";
+    public static string documentTagNormalised = "select id from document";
 
     public DocumentID[] GetResults(Archive archive){
 
@@ -142,7 +142,7 @@ public class Query {
         var documents = new List<DocumentID>();
 
         var com = db.CreateCommand();
-		com.CommandText = @$"select distinct ID from ({root.ToSQL(archive)});";
+		com.CommandText = @$"select distinct id from ({root.ToSQL(archive)});";
 		
         Console.WriteLine("SQL: " + com.CommandText);
 

--- a/Mage.CLI/Engine/QueryAST.cs
+++ b/Mage.CLI/Engine/QueryAST.cs
@@ -142,8 +142,8 @@ public class Query {
         var documents = new List<DocumentID>();
 
         var com = db.CreateCommand();
-		com.CommandText = @$"select distinct id from ({root.ToSQL(archive)});";
-		
+        com.CommandText = @$"select distinct id from ({root.ToSQL(archive)});";
+        
         Console.WriteLine("SQL: " + com.CommandText);
 
         var reader = com.ExecuteReader();

--- a/Mage.CLI/Engine/Taxonym.cs
+++ b/Mage.CLI/Engine/Taxonym.cs
@@ -2,6 +2,6 @@ namespace Mage.Engine;
 
 public struct Taxonym {
     public TaxonymID? id;
-    public TaxonymID? canonicalParentID;
-	public string canonicalAlias;
+    public TaxonymID? canonParentID;
+    public string canonAlias;
 }

--- a/Mage.CLI/Resources/DB/setup.sqlite.sql
+++ b/Mage.CLI/Resources/DB/setup.sqlite.sql
@@ -1,123 +1,115 @@
-create table Document (
-    ID integer not null primary key autoincrement,
-    Hash text not null,
-    FileName text not null,
-    Extension text not null,
-    IngestTimestamp integer not null,
-    Comment text
+create table document (
+    id integer not null primary key autoincrement,
+    hash text not null,
+    file_name text not null,
+    extension text not null,
+    ingested_at integer not null,
+    comment text
 );
 
-create table TaxonymAlias (
-	TaxonymID integer not null,
-	Alias text not null,
+create table taxonym_alias (
+	taxonym_id integer not null,
+	alias text not null,
 
-	foreign key (TaxonymID) references Taxonym(ID)
+	foreign key (taxonym_id) references taxonym(id)
 		deferrable initially deferred,
-	primary key (TaxonymID, Alias)
+	primary key (taxonym_id, alias)
 );
 
-create table TaxonymParent (
-	ChildID integer not null,
-	ParentID integer not null,
+create table taxonym_parent (
+	child_id integer not null,
+	parent_id integer not null,
 
-	foreign key (ChildID) references Taxonym(ID)
+	foreign key (child_id) references taxonym(id)
         deferrable initially deferred,
-	foreign key (ParentID) references Taxonym(ID)
+	foreign key (parent_id) references taxonym(id)
         deferrable initially deferred,
-	primary key (ChildID, ParentID)
+	primary key (child_id, parent_id)
 );
 
-create table Taxonym (
-	ID integer not null primary key autoincrement,
-	CanonicalParentID integer,
-	CanonicalAlias text not null,
+create table taxonym (
+	id integer not null primary key autoincrement,
+	canon_parent_id integer,
+	canon_alias text not null,
 
-	foreign key (CanonicalParentID) references Taxonym(ID),
-	foreign key (ID, CanonicalAlias) references TaxonymAlias(TaxonymID, Alias)
+	foreign key (canon_parent_id) references taxonym(id),
+	foreign key (id, canon_alias) references taxonym_alias(taxonym_id, alias)
 		deferrable initially deferred,
-	foreign key (ID, CanonicalParentID) references TaxonymParent(ChildID, ParentID)
+	foreign key (id, canon_parent_id) references taxonym_parent(child_id, parent_id)
 		deferrable initially deferred,
-	unique(CanonicalParentID, CanonicalAlias)
+	unique(canon_parent_id, canon_alias)
 );
 
 begin transaction;
-insert into TaxonymAlias (TaxonymID, Alias) values (1, "");
-insert into Taxonym (CanonicalParentID, CanonicalAlias) values (null, ""); -- root taxonym
+insert into taxonym_alias (taxonym_id, alias) values (1, "");
+insert into taxonym (canon_parent_id, canon_alias) values (null, ""); -- root taxonym
 commit;
 
 
 
 
 
-create table Tag (
-	ID integer not null primary key autoincrement,
-	TaxonymID integer not null,
+create table tag (
+	id integer not null primary key autoincrement,
+	taxonym_id integer not null,
 
-	foreign key (TaxonymID) references Taxonym(ID),
-	unique (TaxonymID)
+	foreign key (taxonym_id) references taxonym(id),
+	unique (taxonym_id)
 );
 
-create table DocumentTag (
-	DocumentID integer not null,
-   TagID integer not null,
+create table document_tag (
+	document_id integer not null,
+    tag_id integer not null,
 	
-	foreign key (DocumentID) references Document(ID),
-	foreign key (TagID) references Tag(ID),
-	primary key (DocumentID, TagID)
+	foreign key (document_id) references document(id),
+	foreign key (tag_id) references tag(id),
+	primary key (document_id, tag_id)
 );
 
-create table TagParameterisation (
-	TagID integer not null primary key,
+create table tag_parameter (
+	tag_id integer not null primary key,
 
-	foreign key (TagID) references Tag(ID)
+	foreign key (tag_id) references tag(id)
 );
 
-create table DocumentTagParameter (
-	DocumentID integer not null,
-   TagID integer not null,
-	Value integer not null,
+create table document_tag_parameter (
+	document_id integer not null,
+    tag_id integer not null,
+	value integer not null,
 
-	foreign key (DocumentID, TagID) references DocumentTag(DocumentID, TagID),
-	foreign key (TagID) references TagParameterisation(TagID),
-	primary key (DocumentID, TagID)
+	foreign key (document_id, tag_id) references document_tag(document_id, tag_id),
+	foreign key (tag_id) references tag_parameter(tag_id),
+	primary key (document_id, tag_id)
 );
 
-
-
-create table TagImplication (
-	AntecedentID integer not null,
-	ConsequentID integer not null,
+create table tag_implication (
+	antecedent_id integer not null,
+	consequent_id integer not null,
 	
-	foreign key (AntecedentID) references Tag(ID),
-	foreign key (ConsequentID) references Tag(ID),
-	primary key (AntecedentID, ConsequentID)
+	foreign key (antecedent_id) references tag(id),
+	foreign key (consequent_id) references tag(id),
+	primary key (antecedent_id, consequent_id)
 );
 
-create table Series (
-	ID integer not null primary key autoincrement,
-	Title text,
-	Comment text
+create table collection (
+	id integer not null primary key autoincrement,
+	title text,
+	comment text
 );
 
-create table SeriesDocument (
-	SeriesID integer not null,
-	DocumentID integer not null,
+create table collection_document (
+	collection_id integer not null,
+	document_id integer not null,
 
-	foreign key (SeriesID) references Series(ID),
-	foreign key (DocumentID) references Document(ID),
-	primary key (SeriesID, DocumentID)
+	foreign key (collection_id) references collection(id),
+	foreign key (document_id) references document(id),
+	primary key (collection_id, document_id)
 );
 
-create table Source (
-	ID integer not null primary key autoincrement,
-	URL text not null
-);
-
-create table DocumentSource (
-	DocumentID integer not null,
-	SourceID integer not null, 
+create table document_source (
+	document_id integer not null,
+	url text not null, 
 	
-	foreign key (DocumentID) references Document(ID),
-	foreign key (SourceID) references Source(ID),
-	primary key (SourceID, DocumentID)
+	foreign key (document_id) references document(id),
+	primary key (document_id, url)
 );


### PR DESCRIPTION
Pascal case identifiers in SQL have been replaced with snake case identifiers everywhere; additionally, some columns have been renamed to have less cumbersome names. Singular nouns have been maintained. This is a breaking change that resolves #31