### PR TITLE
Safer document deletion

### DIFF
--- a/Mage.CLI/CLI/Delete.cs
+++ b/Mage.CLI/CLI/Delete.cs
@@ -25,6 +25,8 @@ public static partial class CLICommands {
 
         com.SetHandler((docRef) => {
             var documentID = (DocumentID)ObjectRef.ResolveDocument(ctx.archive, docRef)!;
+            var documentHash = ctx.archive.GetDocumentHash(documentID);
+            Console.WriteLine($"document {documentHash} marked for deletion");
             ctx.archive.DocumentDelete(documentID);
         }, docRefArgument);
 

--- a/Mage.CLI/CLI/Doc.cs
+++ b/Mage.CLI/CLI/Doc.cs
@@ -38,7 +38,8 @@ public static partial class CLICommands {
             Console.WriteLine($"  Extension: {doc.extension}");
             Console.WriteLine($"  Ingest timestamp: {doc.ingestedAt}");
             Console.WriteLine($"  Comment: {(doc.comment is null ? "<none>" : doc.comment)}");
-            
+            Console.WriteLine($"  Deleted: {(doc.isDeleted ? "yes" : "no")}");
+
             var tagNames = ctx.archive.DocumentGetTags(docID).Select(tagID => ctx.archive.TagAsString(tagID));
             Console.WriteLine($"  Tags: {string.Join(" ", tagNames)}");
 

--- a/Mage.CLI/Engine/Archive.cs
+++ b/Mage.CLI/Engine/Archive.cs
@@ -163,6 +163,7 @@ public class Archive {
 
     public void DocumentDelete(DocumentID documentID){
 
+        /*
         var doc = (Document)DocumentGet(documentID)!;
 
         File.Move($"{fileDir}{doc.hash}", $"{mageDir}{OUT_DIR_PATH}{doc.fileName}.{doc.extension}");
@@ -177,6 +178,10 @@ public class Archive {
         
         db.EnsureConnected();
         db.DeleteDocument(documentID);
+        */
+
+        db.EnsureConnected();
+        db.UpdateDocumentIsDeleted(documentID, true);
 
     }
 

--- a/Mage.CLI/Engine/DB/DBCommands.cs
+++ b/Mage.CLI/Engine/DB/DBCommands.cs
@@ -90,4 +90,10 @@ public static class DBCommands {
 
     }
 
+    public static class Update {
+
+        public const string DocumentIsDeletedWhereID = "update document set is_deleted = @is_deleted where id = @id";
+
+    }
+
 }

--- a/Mage.CLI/Engine/DB/DBCommands.cs
+++ b/Mage.CLI/Engine/DB/DBCommands.cs
@@ -6,8 +6,8 @@ public static class DBCommands {
 
     public static class Select {
 
-        public const string Document = "select * from document";
-        public static string DocumentIDClause(string clause) => $"select id from document {clause}";
+        public static string Document(bool public_ = true) => $"select * from {(public_ ? "public_" : "")}document";
+        public static string DocumentIDClause(string clause, bool public_ = true) => $"select id from {(public_ ? "public_" : "")}document {clause}";
         public const string DocumentWherePK = "select * from document where id = @id";
         public const string DocumentWhereHash = "select * from document where hash = @hash";
         public const string DocumentHashWhereID = "select hash from document where id = @id";
@@ -30,15 +30,15 @@ public static class DBCommands {
         public const string TagAntecedentIDWhereID = "select antecedent_id from tag_implication where consequent_id = @consequent_id";
         public const string TagConsequentIDWhereID = "select consequent_id from tag_implication where antecedent_id = @antecedent_id";
 
-        public const string DocumentTag = "select * from document_tag";
+        public static string DocumentTag(bool public_ = true) => $"select * from {(public_ ? "public_" : "")}document_tag";
         public const string DocumentTagIDWhereDocumentID = "select tag_id from document_tag where document_id = @document_id";
-        public const string TagDocumentIDWhereTagID = "select document_id from document_tag where tag_id = @tag_id";
+        public static string TagDocumentIDWhereTagID(bool public_ = true) => $"select document_id from {(public_ ? "public_" : "")}document_tag where tag_id = @tag_id";
     
     }
 
     public static class Count {
 
-        public const string DocumentTagWhereTagID = "select count(*) from document_tag where tag_id = @tag_id";
+        public static string DocumentTagWhereTagID(bool public_ = true) => $"select count(*) from {(public_ ? "public_" : "")}document_tag where tag_id = @tag_id";
         public const string DocumentTagWhereDocumentID = "select count(*) from document_tag where document_id = @document_id";
    
     }

--- a/Mage.CLI/Engine/DB/DBEngine.cs
+++ b/Mage.CLI/Engine/DB/DBEngine.cs
@@ -264,7 +264,7 @@ public partial class DBEngine {
     public int CountTagDocuments(TagID tagID, SqliteTransaction? transaction = null){
         
         using var com = GenCommand(
-            DBCommands.Count.DocumentTagWhereTagID,
+            DBCommands.Count.DocumentTagWhereTagID(),
             ("tag_id", tagID)
         );
         com.Transaction = transaction;

--- a/Mage.CLI/Engine/DB/DBEngine.cs
+++ b/Mage.CLI/Engine/DB/DBEngine.cs
@@ -107,7 +107,8 @@ public partial class DBEngine {
                 fileName = r.GetString(2),
                 extension = r.GetString(3),
                 ingestedAt = ingestTimestamp,
-                comment = r.IsDBNull(5) ? null : r.GetString(5)
+                comment = r.IsDBNull(5) ? null : r.GetString(5),
+                isDeleted = r.GetBoolean(6)
             };
         });
     }
@@ -507,6 +508,21 @@ public partial class DBEngine {
         RunNonQuery(com3);
 
         transaction.Commit();
+    }
+
+}
+
+// Update
+public partial class DBEngine {
+
+    public void UpdateDocumentIsDeleted(DocumentID documentID, bool isDeleted, SqliteTransaction? transaction = null){
+        using var com = GenCommand(
+            DBCommands.Update.DocumentIsDeletedWhereID,
+            ("id", documentID),
+            ("is_deleted", isDeleted)
+        );
+        com.Transaction = transaction;
+        RunNonQuery(com);
     }
 
 }

--- a/Mage.CLI/Engine/Model/Document.cs
+++ b/Mage.CLI/Engine/Model/Document.cs
@@ -7,4 +7,5 @@ public struct Document {
     public string extension;
     public DateTime ingestedAt;
     public string? comment;
+    public bool isDeleted;
 }

--- a/Mage.CLI/Engine/Query/QueryAST.cs
+++ b/Mage.CLI/Engine/Query/QueryAST.cs
@@ -132,7 +132,7 @@ public class Query {
     public static int tempTableIndex = 0;
     public static string documentTagNormalised = "select id from document";
 
-    public DocumentID[] GetResults(Archive archive){
+    public DocumentID[] GetResults(Archive archive, bool public_ = true){
 
         archive.db.EnsureConnected();
         var db = archive.db.db;
@@ -140,7 +140,12 @@ public class Query {
         var documents = new List<DocumentID>();
 
         var com = db.CreateCommand();
-        com.CommandText = @$"select distinct id from ({root.ToSQL(archive)});";
+        com.CommandText = @$"
+select distinct result.id from 
+    ({root.ToSQL(archive)}) result
+    inner join {(public_ ? "public_": "")}document
+    on result.id = public_document.id;
+        ";
         
         Console.WriteLine("SQL: " + com.CommandText);
 

--- a/Mage.CLI/Resources/DB/setup.sqlite.sql
+++ b/Mage.CLI/Resources/DB/setup.sqlite.sql
@@ -9,7 +9,8 @@ create table document (
     file_name       text not null,
     extension       text not null,
     ingested_at     integer not null,
-    comment         text
+    comment         text,
+    is_deleted      integer not null default 0
 );
 
 ---

--- a/Mage.CLI/Resources/DB/setup.sqlite.sql
+++ b/Mage.CLI/Resources/DB/setup.sqlite.sql
@@ -13,6 +13,16 @@ create table document (
     is_deleted      integer not null default 0
 );
 
+create view public_document as 
+    select * 
+    from document 
+    where is_deleted = 0;
+
+create view deleted_document as 
+    select * 
+    from document 
+    where is_deleted = 1;
+
 ---
 --- TAXONYMS
 ---
@@ -96,6 +106,13 @@ create table document_tag_parameter (
 	primary key (document_id, tag_id)
 );
 
+create view public_document_tag as
+    select document_tag.*
+    from 
+        document_tag inner join document
+        on document.id = document_tag.document_id
+    where document.is_deleted = 0;
+
 ---
 --- COLLECTIONS
 ---
@@ -115,6 +132,13 @@ create table collection_document (
 	primary key (collection_id, document_id)
 );
 
+create view collection_public_document as
+    select collection_document.*
+    from
+        collection_document inner join document
+        on document.id = collection_document.document_id
+    where document.is_deleted = 0;
+
 ---
 --- SOURCES
 ---
@@ -126,3 +150,10 @@ create table document_source (
 	foreign key (document_id) references document(id),
 	primary key (document_id, url)
 );
+
+create view public_document_source as
+    select document_source.*
+    from 
+        document_source inner join document
+        on document.id = document_source.document_id
+    where document.is_deleted = 0;


### PR DESCRIPTION
Rather than documents being immediately erased from the database when using the `mage delete` command, they are merely marked as deleted and hidden from results through the use of SQL views like `public_document`.

However, this does remove any option to truly delete a document. This will need be re-added at some point. The user can manually delete the document's file if they wish, and since the document is marked as deleted in the database, this should not be problematic, except as regards dangling hard links in views.

'Public' may not be ideal terminology here.

Resolves #30 