### PR TITLE
Semantic versioning

### DIFF
--- a/Mage.CLI/CLI/Program.cs
+++ b/Mage.CLI/CLI/Program.cs
@@ -10,8 +10,17 @@ var ctx = new CLIContext(){
     archive = null
 };
 
-if(Directory.Exists(ctx.mageDir))
-    ctx.archive = Archive.Load(ctx.mageDir, archiveDir);
+try {
+    if(Directory.Exists(ctx.mageDir))
+        ctx.archive = Archive.Load(ctx.mageDir, archiveDir);
+} catch(Archive.IncompatibleArchiveException ex){
+    var ogFGColor = Console.ForegroundColor;
+    Console.ForegroundColor = ConsoleColor.Red;
+    Console.Write("ERROR: ");
+    Console.ForegroundColor = ogFGColor;
+    Console.WriteLine(ex);
+    return;
+}
 
 var rootCommand = CLICommands.CreateRoot(ctx);
 rootCommand.Invoke(args);

--- a/Mage.CLI/Engine/Archive.cs
+++ b/Mage.CLI/Engine/Archive.cs
@@ -115,7 +115,7 @@ public class Archive {
     public const string DB_FILE_PATH = "db.sqlite";
 
     public static readonly SemanticVersion VERSION = new SemanticVersion(){
-        releaseType = 0,
+        releaseType = -1,
         major = 8,
         minor = 0,
         patch = 0


### PR DESCRIPTION
The single major version number has been replaced with a four part version:
- Release type (alpha, beta, release)
- Major (tracks breaking changes, like the old version number)
- Minor (tracks feature additions)
- Patch (tracks bug fixes)

Starting now, the tool is Mage alpha_8.0.0.

Mage also now checks whether the archive in the current directory was made in a compatible version.

![image](https://github.com/kaspiana/mage/assets/169970552/b8cb07a8-523b-4930-b203-4f2057e4cbc4)

Resolves #32 


