### PR TITLE
[alpha_9.0.0] Flatten archive directory structure

### DIFF
--- a/Mage.CLI/CLI/Bind.cs
+++ b/Mage.CLI/CLI/Bind.cs
@@ -13,7 +13,7 @@ public static partial class CLICommands {
         };
 
         com.SetHandler(() => {
-            Console.Write( File.ReadAllText($"{ctx.archive.mageDir}{Archive.BIND_FILE_PATH}") );
+            Console.Write( File.ReadAllText($"{ctx.archive.archiveDir}{Archive.BIND_FILE_PATH}") );
         });
 
         return com;

--- a/Mage.CLI/CLI/Doc.cs
+++ b/Mage.CLI/CLI/Doc.cs
@@ -61,7 +61,7 @@ public static partial class CLICommands {
             var doc = (Document)ctx.archive.DocumentGet(docID)!;
 
             var viewIndex = ctx.archive.ViewAdd(Archive.OPEN_VIEW_NAME, docID);
-            var viewFilePath = $"{ctx.archive.mageDir}{Archive.VIEWS_DIR_PATH}{Archive.OPEN_VIEW_NAME}/{viewIndex}~{doc.hash}.{doc.extension}";
+            var viewFilePath = $"{ctx.archive.archiveDir}{Archive.VIEWS_DIR_PATH}{Archive.OPEN_VIEW_NAME}/{viewIndex}~{doc.hash}.{doc.extension}";
 
             using Process fileOpener = new Process();
 

--- a/Mage.CLI/CLI/Program.cs
+++ b/Mage.CLI/CLI/Program.cs
@@ -2,17 +2,16 @@
 using System.Diagnostics;
 using Mage.Engine;
 
-var archiveDir = Directory.GetCurrentDirectory().Replace('\\', '/') + "/";
+var _archiveDir = Directory.GetCurrentDirectory().Replace('\\', '/') + "/";
 
 var ctx = new CLIContext(){
-    archiveDir = archiveDir,
-    mageDir = $"{archiveDir}.mage/",
+    archiveDir = _archiveDir,
     archive = null
 };
 
 try {
-    if(Directory.Exists(ctx.mageDir))
-        ctx.archive = Archive.Load(ctx.mageDir, archiveDir);
+    if(Archive.Exists(ctx.archiveDir))
+        ctx.archive = Archive.Load(ctx.archiveDir);
     else {
         var ogFGColor = Console.ForegroundColor;
         Console.ForegroundColor = ConsoleColor.Yellow;


### PR DESCRIPTION
Rather than document files being stored in the root directory, with all other files being stored in the `.mage` folder, everything will now be in the root, with document files in a `files` folder. This allows the user to place files such as notes and scripts in the root directory without worrying they will be interfered with by Mage.