### PR TITLE
Delete taxonym along with tag

### DIFF
--- a/Mage.CLI/CLI/Delete.cs
+++ b/Mage.CLI/CLI/Delete.cs
@@ -54,15 +54,21 @@ public static partial class CLICommands {
         var tagRefArgument = new Argument<string>(
             name: "tag"
         );
+        
+        var preserveTaxOption = new Option<bool>(
+            name: "--preserve-taxonym",
+            getDefaultValue: () => false
+        );
 
         var com = new Command("tag", "Delete tag."){
-            tagRefArgument
+            tagRefArgument,
+            preserveTaxOption
         };
 
-        com.SetHandler((tagRef) => {
+        com.SetHandler((tagRef, preserveTax) => {
             var tagID = (TagID)ObjectRef.ResolveTag(ctx.archive, tagRef)!;
-            ctx.archive.TagDelete(tagID);
-        }, tagRefArgument);
+            ctx.archive.TagDelete(tagID, preserveTax);
+        }, tagRefArgument, preserveTaxOption);
 
         return com;
     }

--- a/Mage.CLI/Engine/Archive.cs
+++ b/Mage.CLI/Engine/Archive.cs
@@ -119,7 +119,7 @@ public class Archive {
         releaseType = -1,
         major = 9,
         minor = 1,
-        patch = 0
+        patch = 1
     };
 
     public const string IN_VIEW_NAME = "in";

--- a/Mage.CLI/Engine/Archive.cs
+++ b/Mage.CLI/Engine/Archive.cs
@@ -356,9 +356,15 @@ public class Archive {
         return TagCreate((TaxonymID)TaxonymCreate(parentID, name)!);
     }
 
-    public void TagDelete(TagID tagID){
+    public void TagDelete(TagID tagID, bool preserveTaxonym = false){
+        var tag = TagGet(tagID);
+
         db.EnsureConnected();
         db.DeleteTag(tagID);
+
+        if(!preserveTaxonym){
+            db.DeleteTaxonym((TaxonymID)tag?.taxonymID);
+        }
     }
 
     public void TagAddImplication(TagID tagID, TagID consequentID){

--- a/Mage.CLI/Engine/DB/DBEngine.cs
+++ b/Mage.CLI/Engine/DB/DBEngine.cs
@@ -493,7 +493,7 @@ public partial class DBEngine {
 
         using var com2 = GenCommand(
             DBCommands.Delete.TaxonymAliasWhereTaxonymID,
-            ("taxonym_idid", taxonymID)
+            ("taxonym_id", taxonymID)
         );
         com2.Transaction = transaction;
 


### PR DESCRIPTION
When deleting a tag with `mage delete tag`, its corresponding taxonym will now also be deleted unless the `--preserve-taxonym` option is passed.

Resolves #27 