### PR TITLE
Ingest list file

### DIFF
--- a/Mage.CLI/CLI/Ingest.cs
+++ b/Mage.CLI/CLI/Ingest.cs
@@ -17,12 +17,21 @@ public static partial class CLICommands {
         var com = new Command("ingest", "Ingest files in inbox into archive.")
         {
             commentOption,
-            ComIngestFrom(ctx, commentOption)
+            ComIngestFrom(ctx, commentOption),
+            ComIngestList(ctx)
         };
         com.SetHandler((comment) => {
             ctx.archive.Ingest();
         }, commentOption);
 
+        return com;
+    }
+
+    public static Command ComIngestList(CLIContext ctx){
+        var com = new Command("list", "Ingest files from ingest list.");
+        com.SetHandler(() => {
+            ctx.archive.IngestList();
+        });
         return com;
     }
 

--- a/Mage.CLI/Engine/Archive.cs
+++ b/Mage.CLI/Engine/Archive.cs
@@ -116,7 +116,7 @@ public class Archive {
     public const string DB_FILE_PATH = DATA_DIR_PATH + "db.sqlite";
     public const string INGEST_LIST_FILE_PATH = DATA_DIR_PATH + "ingestlist.txt";
 
-    public const string INGEST_LIST_FILE_HEADER = "# file_path | comment | tag list | series\n";
+    public const string INGEST_LIST_FILE_HEADER = "# file_path | comment | tag list | series | source list\n";
 
     public static readonly SemanticVersion VERSION = new SemanticVersion(){
         releaseType = -1,
@@ -289,7 +289,7 @@ public class Archive {
                         .ToArray()
         );
 
-        // filePath | comment | tags | series
+        // filePath | comment | tag list | series / source list
 
         var i = 0;
         foreach(var ingestListItem in ingestListItems){
@@ -307,6 +307,7 @@ public class Archive {
                         .Where((s) => s.Count() > 0)
                         .Select((s) => ObjectRef.ResolveTag(this, s));
             //var series = ingestListItem[3];     // TODO
+            //var sources = ingestListItem[4];    // TODO
 
             Console.WriteLine($"ingested document #{i}:");
             Console.WriteLine($"  file path: {filePath}");

--- a/Mage.CLI/Engine/Archive.cs
+++ b/Mage.CLI/Engine/Archive.cs
@@ -121,8 +121,8 @@ public class Archive {
     public static readonly SemanticVersion VERSION = new SemanticVersion(){
         releaseType = -1,
         major = 9,
-        minor = 1,
-        patch = 1
+        minor = 2,
+        patch = 0
     };
 
     public const string IN_VIEW_NAME = "in";

--- a/Mage.CLI/Engine/Archive.cs
+++ b/Mage.CLI/Engine/Archive.cs
@@ -116,7 +116,7 @@ public class Archive {
     public const string DB_FILE_PATH = DATA_DIR_PATH + "db.sqlite";
     public const string INGEST_LIST_FILE_PATH = DATA_DIR_PATH + "ingestlist.txt";
 
-    public const string INGEST_LIST_FILE_HEADER = "# file_path | comment | tag list | series | source list\n";
+    public const string INGEST_LIST_FILE_HEADER = "# file path | comment | tag list | series | source list\n";
 
     public static readonly SemanticVersion VERSION = new SemanticVersion(){
         releaseType = -1,


### PR DESCRIPTION
The file `data/ingestlist.txt` can now be used to supply the tool with a list of files to ingest along with their metadata. The file has a tabulated format, with the columns `file path`, `comment`, `tag list`, `series`, `source list`, the latter two of which are unimplemented.

(The file also permits commas prepended with `#`.)

```
# file path | comment | tag list | series | source list
c:/home/images/20240304_000206.jpg | "the mug" | rose_lalonde | |
c:/home/images/20240305_140745.jpg | | rose_lalonde kanaya_maryam | |
```

```bash
mage ingest list
```