### PR TITLE
Metatags in queries

### DIFF
--- a/Mage.CLI/Engine/Archive.cs
+++ b/Mage.CLI/Engine/Archive.cs
@@ -121,7 +121,7 @@ public class Archive {
     public static readonly SemanticVersion VERSION = new SemanticVersion(){
         releaseType = -1,
         major = 9,
-        minor = 2,
+        minor = 3,
         patch = 0
     };
 

--- a/Mage.CLI/Engine/Query/QueryAST.cs
+++ b/Mage.CLI/Engine/Query/QueryAST.cs
@@ -1,6 +1,14 @@
 namespace Mage.Engine.AST;
 
-
+public enum QueryParameterOperator {
+    Equals,
+    NotEquals,
+    Greater,
+    GreaterOrEquals,
+    Lesser,
+    LesserOrEquals,
+    Like
+}
 
 public abstract class QueryNode {
     public abstract string ToSQL(Archive archive);
@@ -25,6 +33,43 @@ public class QueryNodeNone : QueryNode {
     public override string ToSQL(Archive archive)
     {
         return $"select id from document where 1=0";
+    }
+}
+public class QueryNodeMetaTag : QueryNode {
+
+    public string tag;
+    public QueryParameterOperator op;
+    public string param;
+
+    public override string ToString()
+    {
+        var opStr = "=";
+        switch(op){
+            case QueryParameterOperator.Equals: opStr = "="; break; 
+            case QueryParameterOperator.NotEquals: opStr = "!="; break;
+            case QueryParameterOperator.Greater: opStr = ">"; break;
+            case QueryParameterOperator.GreaterOrEquals: opStr = ">="; break;
+            case QueryParameterOperator.Lesser: opStr = "<"; break;
+            case QueryParameterOperator.LesserOrEquals: opStr = "<="; break;
+            case QueryParameterOperator.Like: opStr = "like"; break;
+        }
+        return $"(meta '{tag}' {opStr} {param})";
+    }
+
+    public override string ToSQL(Archive archive)
+    {
+        // sufficient for basic metatags
+        var opStr = "=";
+        switch(op){
+            case QueryParameterOperator.Equals: opStr = "="; break; 
+            case QueryParameterOperator.NotEquals: opStr = "!="; break;
+            case QueryParameterOperator.Greater: opStr = ">"; break;
+            case QueryParameterOperator.GreaterOrEquals: opStr = ">="; break;
+            case QueryParameterOperator.Lesser: opStr = "<"; break;
+            case QueryParameterOperator.LesserOrEquals: opStr = "<="; break;
+            case QueryParameterOperator.Like: opStr = "like"; break;
+        }
+        return $"select id from document where {tag} {opStr} {param}";
     }
 }
 public class QueryNodeTag : QueryNode {


### PR DESCRIPTION
Documents can be queried not only by their tags but also by their metadata, using the operators `=` (implicit), `!=`, `<`, `>`, `<=`, `>=`, and `like` (as in SQL).

```bash
mage search "extension('jpg')"
```

```bash
mage search "id(>100)"
```

```bash
mage search "file_name(like '%tumblr%')"
```

Resolves #24. In this issue, they were referred to as pseudotags, but the term metatags will be used now.