### PR TITLE
List of sources in document information

### DIFF
--- a/Mage.CLI/CLI/Doc.cs
+++ b/Mage.CLI/CLI/Doc.cs
@@ -51,6 +51,12 @@ public static partial class CLICommands {
                 ctx.archive.ViewAdd(boundView, docID);
             }
 
+            var sources = ctx.archive.DocumentGetSources(docID);
+            Console.WriteLine($"  Sources: {(sources.Count() == 0 ? "<none>" : "")}");
+            foreach(var source in sources){
+                Console.WriteLine($"   * {source}");
+            }
+
         }, docRefArgument, reflectOption);
         
         return com;

--- a/Mage.CLI/Engine/Archive.cs
+++ b/Mage.CLI/Engine/Archive.cs
@@ -121,7 +121,7 @@ public class Archive {
     public static readonly SemanticVersion VERSION = new SemanticVersion(){
         releaseType = -1,
         major = 9,
-        minor = 4,
+        minor = 5,
         patch = 0
     };
 


### PR DESCRIPTION
When using `mage doc [doc]`, the document's sources will be listed.

```bash
> mage doc in/0
document [...]
  Archive ID: /1
  File name: 20230721_014410
  Extension: jpg
  Ingest timestamp: 5/23/2024 7:42:09 PM
  Comment: <none>
  Deleted: no
  Tags: [...]
  Sources:
   * mockup.com
```