### PR TITLE
Tree view of taxonyms

### DIFF
--- a/Mage.CLI/CLI/Taxonyms.cs
+++ b/Mage.CLI/CLI/Taxonyms.cs
@@ -1,29 +1,76 @@
 using System.CommandLine;
+using System.Reflection;
 using System.Security.Cryptography.X509Certificates;
 using Mage.Engine;
 using SQLitePCL;
 
 public static partial class CLICommands {
 
+    private const char BOX_DRAWING_LR = '─';
+    private const char BOX_DRAWING_TB = '│';
+    private const char BOX_DRAWING_TBR = '├';
+    private const char BOX_DRAWING_BR = '┌';
+    private const char BOX_DRAWING_TR = '└';
+
+    private static void PrintTaxonymTree(CLIContext ctx, TaxonymID taxonymID, Stack<bool> stack){
+        var taxonym = ctx.archive.TaxonymGet(taxonymID);
+
+        var i = 0;
+        foreach(var level in stack.Reverse()){
+            if(i == stack.Count() - 1){
+                if(!stack.First()){
+                    Console.Write(BOX_DRAWING_TR);
+                } else {
+                    Console.Write(BOX_DRAWING_TBR);
+                }
+            } else {
+                if(level){
+                    Console.Write(BOX_DRAWING_TB);
+                } else {
+                    Console.Write(' ');
+                }
+            }
+            if(i < stack.Count() - 1){
+                Console.Write(' ');
+                Console.Write(' ');
+            }
+            i++;
+        }
+
+        if(taxonymID != Archive.ROOT_TAXONYM_ID){
+            Console.Write($"{BOX_DRAWING_LR} ");
+
+            var ogFGColor = Console.ForegroundColor;
+            Console.ForegroundColor = ConsoleColor.Yellow;
+            Console.Write($"{taxonym?.canonAlias}");
+            Console.ForegroundColor = ogFGColor;
+
+            Console.Write($" (/{taxonymID}) ");
+            
+            ctx.archive.db.EnsureConnected();
+            var tagID = ctx.archive.db.ReadTagID(taxonymID);
+            if(tagID is not 0) // FIX
+                Console.Write($"(tag /{tagID})");
+
+            Console.WriteLine();
+        }
+
+        var children = ctx.archive.TaxonymGetChildren(taxonymID);
+        var j = 0;
+        foreach(var child in children){
+            stack.Push(j != children.Count() - 1);
+            PrintTaxonymTree(ctx, child, stack);
+            stack.Pop();
+            j++;
+        }
+    }
+
     public static Command ComTaxonyms(CLIContext ctx){
         var com = new Command("taxonyms", "List all taxonyms.");
 
         com.SetHandler(() => {
-            var taxonymIDs = ctx.archive.TaxonymsQuery("");
-            var taxonyms = taxonymIDs.Select((id) => ctx.archive.TaxonymGet(id));
-
-            foreach(var taxonym in taxonyms){
-                if(taxonym?.id == Archive.ROOT_TAXONYM_ID){
-                    Console.WriteLine($" * /{taxonym?.id}: <root>");
-                } else {
-                    if(taxonym?.canonParentID == Archive.ROOT_TAXONYM_ID){
-                        Console.WriteLine($" * /{taxonym?.id}: {taxonym?.canonAlias}");
-                    } else {
-                        var parentTaxonymName = ctx.archive.TaxonymGet((TaxonymID)taxonym?.canonParentID)?.canonAlias;
-                        Console.WriteLine($" * /{taxonym?.id}: {parentTaxonymName}:{taxonym?.canonAlias}");
-                    }
-                }
-            }
+            var taxonymID = Archive.ROOT_TAXONYM_ID;
+            PrintTaxonymTree(ctx, taxonymID, new Stack<bool>());
         });
 
         return com;

--- a/Mage.CLI/Engine/Archive.cs
+++ b/Mage.CLI/Engine/Archive.cs
@@ -121,7 +121,7 @@ public class Archive {
     public static readonly SemanticVersion VERSION = new SemanticVersion(){
         releaseType = -1,
         major = 9,
-        minor = 5,
+        minor = 6,
         patch = 0
     };
 


### PR DESCRIPTION
When using `mage taxonyms`, taxonyms will now be displayed as a printed tree rather than a flat list.

![image](https://github.com/kaspiana/mage/assets/169970552/9616d2a7-d448-4de5-9e2d-bad0a5fdd3e8)

Resolves #6 