### PR TITLE
Document media metadata

### DIFF
--- a/Mage.CLI/CLI/Doc.cs
+++ b/Mage.CLI/CLI/Doc.cs
@@ -49,8 +49,43 @@ public static partial class CLICommands {
                 default: fileSizeStr = $"{doc.fileSize / (1 << 30)} GB"; break;
             }
             Console.WriteLine($"  File size: {fileSizeStr}");
+            
             Console.WriteLine($"  Added at: {doc.addedAt}");
             Console.WriteLine($"  Updated at: {doc.updatedAt}");
+
+            var mediaMetadata = ctx.archive.DocumentGetMetadata(docID);
+            switch(mediaMetadata){
+                case MediaMetadataBinary mm:
+                    Console.WriteLine("  Media type: binary");
+                break;
+
+                case MediaMetadataText mm:
+                    Console.WriteLine("  Media type: text");
+                break;
+
+                case MediaMetadataImage mm: 
+                    Console.WriteLine("  Media type: image");
+                    Console.WriteLine($"    Image dimension: {mm.width}x{mm.height}");
+                break;
+
+                case MediaMetadataAnimation mm: 
+                    Console.WriteLine("  Media type: animation");
+                    Console.WriteLine($"    Animation dimension: {mm.width}x{mm.height}");
+                    Console.WriteLine($"    Animation duration: {mm.duration} ms");
+                break;
+
+                case MediaMetadataAudio mm:
+                    Console.WriteLine("  Media type: audio");
+                    Console.WriteLine($"    Audio duration: {mm.duration} ms");
+                break;
+
+                case MediaMetadataVideo mm: 
+                    Console.WriteLine("  Media type: video");
+                    Console.WriteLine($"    Video dimension: {mm.width}x{mm.height}");
+                    Console.WriteLine($"    Video duration: {mm.duration} ms");
+                break;
+            }
+
             Console.WriteLine($"  Deleted: {(doc.isDeleted ? "yes" : "no")}");
             if(doc.comment is null)
                 Console.WriteLine($"  Comment: <none>");
@@ -63,7 +98,7 @@ public static partial class CLICommands {
 
             var tagNames = ctx.archive.DocumentGetTags(docID).Select(tagID => ctx.archive.TagAsString(tagID));
             if(tagNames.Count() == 0)
-                Console.WriteLine("$  Tags: <none>");
+                Console.WriteLine($"  Tags: <none>");
             else {
                 Console.WriteLine($"  Tags:");
                 Console.WriteLine($"   {string.Join(" ", tagNames)}");

--- a/Mage.CLI/Engine/Archive.cs
+++ b/Mage.CLI/Engine/Archive.cs
@@ -353,7 +353,7 @@ public class Archive {
             fileSize = (int)fileInfo.Length,
             mediaType = mediaMetadata.mediaType,
             comment = comment
-        });
+        }, mediaMetadata);
 
         ViewAdd("in", documentID);
 

--- a/Mage.CLI/Engine/Archive.cs
+++ b/Mage.CLI/Engine/Archive.cs
@@ -332,7 +332,7 @@ public class Archive {
     public DocumentID? IngestFile(string filePath, string? comment = null){
         var fileInfo = new FileInfo(filePath);
         var fileName = Path.GetFileNameWithoutExtension(filePath);
-        var extension = Path.GetExtension(filePath)[1..];
+        var fileExt = Path.GetExtension(filePath)[1..];
         var hash = HashFile(filePath);
 
         db.EnsureConnected();
@@ -344,11 +344,39 @@ public class Archive {
 
         File.Copy(filePath, $"{archiveDir}{FILES_DIR_PATH}{hash}");
 
+        MediaType mediaType = MediaType.Binary;
+        switch(fileExt){
+            case "txt" or "ini" or "log":
+                mediaType = MediaType.Text;
+            break;
+
+            case "png" or "jpg" or "jpeg" or "avif":
+                mediaType = MediaType.Image;
+            break;
+
+            case "webp": // TODO: check whether it has > 1 frames
+                mediaType = MediaType.Image;
+            break;
+
+            case "gif" : // TODO: check whether it has > 1 frames
+                mediaType = MediaType.Animation;
+            break;
+            
+            case "mp3" or "wav" or "ogg" or "m4a":
+                mediaType = MediaType.Audio;
+            break;
+
+            case "mp4" or "webm" or "mkv" or "mov" or "avi":
+                mediaType = MediaType.Video;
+            break;
+        }
+
         var documentID = db.InsertDocument(new Document(){
             hash = hash,
             fileName = fileName,
-            fileExt = extension,
+            fileExt = fileExt,
             fileSize = (int)fileInfo.Length,
+            mediaType = mediaType,
             comment = comment
         });
 

--- a/Mage.CLI/Engine/Archive.cs
+++ b/Mage.CLI/Engine/Archive.cs
@@ -122,8 +122,8 @@ public class Archive {
     public static readonly SemanticVersion VERSION = new SemanticVersion(){
         releaseType = -1,
         major = 10,
-        minor = 1,
-        patch = 1
+        minor = 2,
+        patch = 0
     };
 
     public const string IN_VIEW_NAME = "in";

--- a/Mage.CLI/Engine/Archive.cs
+++ b/Mage.CLI/Engine/Archive.cs
@@ -344,39 +344,14 @@ public class Archive {
 
         File.Copy(filePath, $"{archiveDir}{FILES_DIR_PATH}{hash}");
 
-        MediaType mediaType = MediaType.Binary;
-        switch(fileExt){
-            case "txt" or "ini" or "log":
-                mediaType = MediaType.Text;
-            break;
-
-            case "png" or "jpg" or "jpeg" or "avif":
-                mediaType = MediaType.Image;
-            break;
-
-            case "webp": // TODO: check whether it has > 1 frames
-                mediaType = MediaType.Image;
-            break;
-
-            case "gif" : // TODO: check whether it has > 1 frames
-                mediaType = MediaType.Animation;
-            break;
-            
-            case "mp3" or "wav" or "ogg" or "m4a":
-                mediaType = MediaType.Audio;
-            break;
-
-            case "mp4" or "webm" or "mkv" or "mov" or "avi":
-                mediaType = MediaType.Video;
-            break;
-        }
+        MediaMetadata mediaMetadata = Media.GetMediaType(filePath);
 
         var documentID = db.InsertDocument(new Document(){
             hash = hash,
             fileName = fileName,
             fileExt = fileExt,
             fileSize = (int)fileInfo.Length,
-            mediaType = mediaType,
+            mediaType = mediaMetadata.mediaType,
             comment = comment
         });
 

--- a/Mage.CLI/Engine/Archive.cs
+++ b/Mage.CLI/Engine/Archive.cs
@@ -855,4 +855,10 @@ public class Archive {
         return db.ReadDocument(documentID);
     }
 
+    public MediaMetadata DocumentGetMetadata(DocumentID documentID){
+        db.EnsureConnected();
+        var mediaType = db.ReadDocument(documentID)?.mediaType ?? MediaType.Binary;
+        return db.ReadDocumentMetadata(documentID, mediaType);
+    }
+
 }

--- a/Mage.CLI/Engine/DB/DBCommands.cs
+++ b/Mage.CLI/Engine/DB/DBCommands.cs
@@ -12,6 +12,10 @@ public static class DBCommands {
         public const string DocumentWhereHash = "select * from document where hash = @hash";
         public const string DocumentHashWhereID = "select hash from document where id = @id";
 
+        public const string ImageMetadataWhereID = "select * from image_metadata where document_id = @document_id";
+        public const string AudioMetadataWhereID = "select * from audio_metadata where document_id = @document_id";
+        public const string VideoMetadataWhereID = "select * from video_metadata where document_id = @document_id";
+
         public const string Taxonym = "select * from taxonym";
         public static string TaxonymIDClause(string clause) => $"select id from taxonym {clause}";
         public const string TaxonymWherePK = "select * from taxonym where id = @id";

--- a/Mage.CLI/Engine/DB/DBCommands.cs
+++ b/Mage.CLI/Engine/DB/DBCommands.cs
@@ -50,6 +50,11 @@ public static class DBCommands {
     public static class Insert {
 
         public const string Document = "insert into document (hash, file_name, file_ext, file_size, media_type, comment) values (@hash, @file_name, @file_ext, @file_size, @media_type, @comment)";
+        
+        public const string ImageMetadata = "insert into image_metadata (document_id, width, height) values (@document_id, @width, @height)";
+        public const string AudioMetadata = "insert into audio_metadata (document_id, duration) values (@document_id, @duration)";
+        public const string VideoMetadata = "insert into video_metadata (document_id, width, height, duration) values (@document_id, @width, @height, @duration)";
+        
         public const string DocumentTag = "insert into document_tag (document_id, tag_id) values (@document_id, @tag_id)";
         public const string DocumentSource = "insert into document_source (document_id, url) values (@document_id, @url)";
         public const string Tag = "insert into tag (taxonym_id) values (@taxonym_id)";

--- a/Mage.CLI/Engine/DB/DBCommands.cs
+++ b/Mage.CLI/Engine/DB/DBCommands.cs
@@ -49,7 +49,7 @@ public static class DBCommands {
 
     public static class Insert {
 
-        public const string Document = "insert into document (hash, file_name, file_ext, file_size, comment) values (@hash, @file_name, @file_ext, @file_size, @comment)";
+        public const string Document = "insert into document (hash, file_name, file_ext, file_size, media_type, comment) values (@hash, @file_name, @file_ext, @file_size, @media_type, @comment)";
         public const string DocumentTag = "insert into document_tag (document_id, tag_id) values (@document_id, @tag_id)";
         public const string DocumentSource = "insert into document_source (document_id, url) values (@document_id, @url)";
         public const string Tag = "insert into tag (taxonym_id) values (@taxonym_id)";

--- a/Mage.CLI/Engine/DB/DBEngine.cs
+++ b/Mage.CLI/Engine/DB/DBEngine.cs
@@ -115,10 +115,11 @@ public partial class DBEngine {
                 fileName = r.GetString(2),
                 fileExt = r.GetString(3),
                 fileSize = r.GetInt32(4),
-                addedAt = unixStart.AddSeconds(r.GetInt32(5)).ToLocalTime(),
-                updatedAt = unixStart.AddSeconds(r.GetInt32(6)).ToLocalTime(),
-                comment = r.IsDBNull(7) ? null : r.GetString(7),
-                isDeleted = r.GetBoolean(8)
+                mediaType = (MediaType)r.GetInt32(5),
+                addedAt = unixStart.AddSeconds(r.GetInt32(6)).ToLocalTime(),
+                updatedAt = unixStart.AddSeconds(r.GetInt32(7)).ToLocalTime(),
+                comment = r.IsDBNull(8) ? null : r.GetString(8),
+                isDeleted = r.GetBoolean(9)
             };
         });
     }

--- a/Mage.CLI/Engine/DB/DBEngine.cs
+++ b/Mage.CLI/Engine/DB/DBEngine.cs
@@ -4,6 +4,7 @@ using System.Data.SqlTypes;
 using System.Diagnostics;
 using System.Resources;
 using Microsoft.Data.Sqlite;
+using SQLitePCL;
 
 namespace Mage.Engine;
 
@@ -115,7 +116,15 @@ public partial class DBEngine {
                 fileName = r.GetString(2),
                 fileExt = r.GetString(3),
                 fileSize = r.GetInt32(4),
-                mediaType = (MediaType)r.GetInt32(5),
+                mediaType = r.GetChar(5) switch {
+                    'b' => MediaType.Binary,
+                    't' => MediaType.Text,
+                    'i' => MediaType.Image,
+                    'm' => MediaType.Animation,
+                    'a' => MediaType.Audio,
+                    'v' => MediaType.Video,
+                    _ => MediaType.Binary
+                },
                 addedAt = unixStart.AddSeconds(r.GetInt32(6)).ToLocalTime(),
                 updatedAt = unixStart.AddSeconds(r.GetInt32(7)).ToLocalTime(),
                 comment = r.IsDBNull(8) ? null : r.GetString(8),
@@ -355,7 +364,15 @@ public partial class DBEngine {
             ("file_name", document.fileName),
             ("file_ext", document.fileExt),
             ("file_size", document.fileSize),
-            ("media_type", document.mediaType),
+            ("media_type", document.mediaType switch {
+                MediaType.Binary => 'b',
+                MediaType.Text => 't',
+                MediaType.Image => 'i',
+                MediaType.Animation => 'm',
+                MediaType.Audio => 'a',
+                MediaType.Video => 'v',
+                _ => MediaType.Binary
+            }),
             ("comment", document.comment)
         );
         com.Transaction = transaction;

--- a/Mage.CLI/Engine/DB/DBEngine.cs
+++ b/Mage.CLI/Engine/DB/DBEngine.cs
@@ -354,6 +354,7 @@ public partial class DBEngine {
             ("file_name", document.fileName),
             ("file_ext", document.fileExt),
             ("file_size", document.fileSize),
+            ("media_type", document.mediaType),
             ("comment", document.comment)
         );
         com.Transaction = transaction;

--- a/Mage.CLI/Engine/DB/DBEngine.cs
+++ b/Mage.CLI/Engine/DB/DBEngine.cs
@@ -356,9 +356,9 @@ public partial class DBEngine {
         RunNonQuery(com);
     }
 
-    public DocumentID InsertDocument(Document document, SqliteTransaction? transaction = null){
+    public DocumentID InsertDocument(Document document, MediaMetadata mediaMetadata, SqliteTransaction? transaction = null){
 
-        using var com = GenCommand(
+        using var com1 = GenCommand(
             DBCommands.Insert.Document,
             ("hash", document.hash),
             ("file_name", document.fileName),
@@ -375,10 +375,60 @@ public partial class DBEngine {
             }),
             ("comment", document.comment)
         );
-        com.Transaction = transaction;
-        RunNonQuery(com);
+        com1.Transaction = transaction;
+        RunNonQuery(com1);
 
         var documentID = (DocumentID)ReadLastInsertRowID();
+
+        switch(mediaMetadata){
+            default: break;
+
+            case MediaMetadataImage mm: {
+                using var com2 = GenCommand(
+                    DBCommands.Insert.ImageMetadata,
+                    ("document_id", documentID),
+                    ("width", mm.width),
+                    ("height", mm.height)
+                );
+                com2.Transaction = transaction;
+                RunNonQuery(com2);
+            } break;
+
+            case MediaMetadataAudio mm: {
+                using var com2 = GenCommand(
+                    DBCommands.Insert.AudioMetadata,
+                    ("document_id", documentID),
+                    ("duration", mm.duration)
+                );
+                com2.Transaction = transaction;
+                RunNonQuery(com2);
+            } break;
+
+            case MediaMetadataAnimation mm: {
+                using var com2 = GenCommand(
+                    DBCommands.Insert.VideoMetadata,
+                    ("document_id", documentID),
+                    ("width", mm.width),
+                    ("height", mm.height),
+                    ("duration", mm.duration)
+                );
+                com2.Transaction = transaction;
+                RunNonQuery(com2);
+            } break;
+
+            case MediaMetadataVideo mm: {
+                using var com2 = GenCommand(
+                    DBCommands.Insert.VideoMetadata,
+                    ("document_id", documentID),
+                    ("width", mm.width),
+                    ("height", mm.height),
+                    ("duration", mm.duration)
+                );
+                com2.Transaction = transaction;
+                RunNonQuery(com2);
+            } break;
+        }
+
         return documentID;
 
     }

--- a/Mage.CLI/Engine/DB/DBEngine.cs
+++ b/Mage.CLI/Engine/DB/DBEngine.cs
@@ -155,6 +155,62 @@ public partial class DBEngine {
         return RunQuerySingle<DocumentID>(com, (r) => (DocumentID)r.GetInt32(0));
     }
 
+    public MediaMetadata ReadDocumentMetadata(DocumentID documentID, MediaType mediaType, SqliteTransaction? transaction = null){
+        switch(mediaType){
+            default: return new MediaMetadataBinary(); break;
+            case MediaType.Text: return new MediaMetadataText(); break;
+
+            case MediaType.Image: {
+                using var com = GenCommand(
+                    DBCommands.Select.ImageMetadataWhereID,
+                    ("document_id", documentID)
+                );
+                com.Transaction = transaction;
+                return RunQuerySingle(com, r => new MediaMetadataImage(){
+                    width = r.GetInt32(1),
+                    height = r.GetInt32(2)
+                })!;
+            } break;
+
+            case MediaType.Animation: {
+                using var com = GenCommand(
+                    DBCommands.Select.VideoMetadataWhereID,
+                    ("document_id", documentID)
+                );
+                com.Transaction = transaction;
+                return RunQuerySingle(com, r => new MediaMetadataAnimation(){
+                    width = r.GetInt32(1),
+                    height = r.GetInt32(2),
+                    duration = r.GetInt32(3)
+                })!;
+            } break;
+
+            case MediaType.Video: {
+                using var com = GenCommand(
+                    DBCommands.Select.VideoMetadataWhereID,
+                    ("document_id", documentID)
+                );
+                com.Transaction = transaction;
+                return RunQuerySingle(com, r => new MediaMetadataVideo(){
+                    width = r.GetInt32(1),
+                    height = r.GetInt32(2),
+                    duration = r.GetInt32(3)
+                })!;
+            } break;
+
+            case MediaType.Audio: {
+                using var com = GenCommand(
+                    DBCommands.Select.AudioMetadataWhereID,
+                    ("document_id", documentID)
+                );
+                com.Transaction = transaction;
+                return RunQuerySingle(com, r => new MediaMetadataAudio(){
+                    duration = r.GetInt32(1)
+                })!;
+            } break;
+        }
+    }
+
     public string[] ReadDocumentSources(DocumentID documentID, SqliteTransaction? transaction = null){
         using var com = GenCommand(
             DBCommands.Select.DocumentSourceWhereID,

--- a/Mage.CLI/Engine/Media.cs
+++ b/Mage.CLI/Engine/Media.cs
@@ -1,3 +1,6 @@
+using System.Reflection;
+using SkiaSharp;
+
 namespace Mage.Engine;
 
 public enum MediaType {
@@ -83,17 +86,32 @@ public class Media {
     }
 
     public static MediaMetadataImage GetImageMetadata(string filePath){
+
+        using var buf = File.OpenRead(filePath);
+        var bmHeader = SKBitmap.DecodeBounds(buf);
+
         return new MediaMetadataImage(){
-            width = 0,
-            height = 0
+            width = bmHeader.Width,
+            height = bmHeader.Height
         };
     }
 
     public static MediaMetadata GetAnimatedImageMetadata(string filePath){
+
+        using var buf = File.OpenRead(filePath);
+        using var codec = SKCodec.Create(buf);
+
+        if(codec.FrameCount == 0){
+            return new MediaMetadataImage(){
+                width = codec.Info.Width,
+                height = codec.Info.Height
+            };
+        }
+
         return new MediaMetadataAnimation(){
-            width = 0,
-            height = 0,
-            length = 0
+            width = codec.Info.Width,
+            height = codec.Info.Height,
+            length = codec.FrameInfo.Sum(fi => fi.Duration) / 1000
         };
     }
 

--- a/Mage.CLI/Engine/Media.cs
+++ b/Mage.CLI/Engine/Media.cs
@@ -1,0 +1,114 @@
+namespace Mage.Engine;
+
+public enum MediaType {
+    Binary,
+    Text,
+    Image,
+    Animation,
+    Audio,
+    Video
+}
+
+public class MediaMetadata {
+    public virtual MediaType mediaType { get => MediaType.Binary; }
+}
+
+public class MediaMetadataBinary : MediaMetadata {
+    override public MediaType mediaType { get => MediaType.Binary; }
+}
+
+public class MediaMetadataText : MediaMetadata {
+    override public MediaType mediaType { get => MediaType.Text; }
+}
+
+public class MediaMetadataImage : MediaMetadata {
+    override public MediaType mediaType { get => MediaType.Image; }
+    public int width;
+    public int height;
+}
+
+public class MediaMetadataAudio : MediaMetadata {
+    override public MediaType mediaType { get => MediaType.Audio; }
+    public int length;
+}
+
+public class MediaMetadataVideo : MediaMetadata {
+    override public MediaType mediaType { get => MediaType.Video; }
+    public int width;
+    public int height;
+    public int length;
+}
+
+public class MediaMetadataAnimation : MediaMetadataVideo {
+    override public MediaType mediaType { get => MediaType.Animation; }
+}
+
+public class Media {
+
+    public static MediaMetadata GetMediaType(string filePath){
+        var fileExt = Path.GetExtension(filePath)[1..];
+        switch(fileExt){
+            default:
+                return GetBinaryMetadata(filePath);
+            break;
+
+            case "txt" or "ini" or "log":
+                return GetTextMetadata(filePath);
+            break;
+
+            case "png" or "jpg" or "jpeg" or "avif":
+                return GetImageMetadata(filePath);
+            break;
+
+            case "webp" or "gif":
+                return GetAnimatedImageMetadata(filePath);
+            break;
+            
+            case "mp3" or "wav" or "ogg" or "m4a":
+                return GetAudioMetadata(filePath);
+            break;
+
+            case "mp4" or "webm" or "mkv" or "mov" or "avi":
+                return GetVideoMetadata(filePath);
+            break;
+        }
+    }
+
+    public static MediaMetadataBinary GetBinaryMetadata(string filePath){
+        return new MediaMetadataBinary();
+    }
+
+    public static MediaMetadataText GetTextMetadata(string filePath){
+        return new MediaMetadataText();
+    }
+
+    public static MediaMetadataImage GetImageMetadata(string filePath){
+        return new MediaMetadataImage(){
+            width = 0,
+            height = 0
+        };
+    }
+
+    public static MediaMetadata GetAnimatedImageMetadata(string filePath){
+        return new MediaMetadataAnimation(){
+            width = 0,
+            height = 0,
+            length = 0
+        };
+    }
+
+    public static MediaMetadataAudio GetAudioMetadata(string filePath){
+        return new MediaMetadataAudio(){
+            length = 0
+        };
+    }
+
+    public static MediaMetadataVideo GetVideoMetadata(string filePath){
+        return new MediaMetadataAnimation(){
+            width = 0,
+            height = 0,
+            length = 0
+        };
+    }
+    
+}

--- a/Mage.CLI/Engine/Media.cs
+++ b/Mage.CLI/Engine/Media.cs
@@ -32,14 +32,14 @@ public class MediaMetadataImage : MediaMetadata {
 
 public class MediaMetadataAudio : MediaMetadata {
     override public MediaType mediaType { get => MediaType.Audio; }
-    public int length;
+    public int duration;
 }
 
 public class MediaMetadataVideo : MediaMetadata {
     override public MediaType mediaType { get => MediaType.Video; }
     public int width;
     public int height;
-    public int length;
+    public int duration;
 }
 
 public class MediaMetadataAnimation : MediaMetadataVideo {
@@ -111,13 +111,13 @@ public class Media {
         return new MediaMetadataAnimation(){
             width = codec.Info.Width,
             height = codec.Info.Height,
-            length = codec.FrameInfo.Sum(fi => fi.Duration) / 1000
+            duration = Math.Max(1, codec.FrameInfo.Sum(fi => fi.Duration) / 1000)
         };
     }
 
     public static MediaMetadataAudio GetAudioMetadata(string filePath){
         return new MediaMetadataAudio(){
-            length = 0
+            duration = 0
         };
     }
 
@@ -125,7 +125,7 @@ public class Media {
         return new MediaMetadataAnimation(){
             width = 0,
             height = 0,
-            length = 0
+            duration = 0
         };
     }
     

--- a/Mage.CLI/Engine/Media.cs
+++ b/Mage.CLI/Engine/Media.cs
@@ -101,7 +101,7 @@ public class Media {
         using var buf = File.OpenRead(filePath);
         using var codec = SKCodec.Create(buf);
 
-        if(codec.FrameCount == 0){
+        if(codec.FrameCount <= 1){
             return new MediaMetadataImage(){
                 width = codec.Info.Width,
                 height = codec.Info.Height
@@ -111,7 +111,7 @@ public class Media {
         return new MediaMetadataAnimation(){
             width = codec.Info.Width,
             height = codec.Info.Height,
-            duration = Math.Max(1, codec.FrameInfo.Sum(fi => fi.Duration) / 1000)
+            duration = codec.FrameInfo.Sum(fi => fi.Duration)
         };
     }
 

--- a/Mage.CLI/Engine/Model/Document.cs
+++ b/Mage.CLI/Engine/Model/Document.cs
@@ -1,11 +1,21 @@
 namespace Mage.Engine;
 
+public enum MediaType {
+    Binary,
+    Text,
+    Image,
+    Animation,
+    Audio,
+    Video
+}
+
 public struct Document {
     public string hash;
     public DocumentID? id;
     public string fileName;
     public string fileExt;
     public int fileSize;
+    public MediaType mediaType;
     public DateTime addedAt;
     public DateTime updatedAt;
     public string? comment;

--- a/Mage.CLI/Engine/Model/Document.cs
+++ b/Mage.CLI/Engine/Model/Document.cs
@@ -1,14 +1,5 @@
 namespace Mage.Engine;
 
-public enum MediaType {
-    Binary,
-    Text,
-    Image,
-    Animation,
-    Audio,
-    Video
-}
-
 public struct Document {
     public string hash;
     public DocumentID? id;

--- a/Mage.CLI/Mage.CLI.csproj
+++ b/Mage.CLI/Mage.CLI.csproj
@@ -8,6 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="SkiaSharp" Version="2.88.8" />
     <PackageReference Include="Sprache" Version="2.3.1" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="8.0.5" />

--- a/Mage.CLI/Resources/DB/setup.sqlite.sql
+++ b/Mage.CLI/Resources/DB/setup.sqlite.sql
@@ -46,7 +46,7 @@ create table image_metadata (
 create table audio_metadata (
     document_id     integer not null primary key,
 
-    duration        integer not null, -- seconds
+    duration        integer not null, -- milliseconds
 
     foreign key (document_id) references document(id)
 );
@@ -57,7 +57,7 @@ create table video_metadata (
 
     width           integer not null,
     height          integer not null,
-    duration        integer not null, -- seconds
+    duration        integer not null, -- milliseconds
 
     foreign key (document_id) references document(id)
 );

--- a/Mage.CLI/Resources/DB/setup.sqlite.sql
+++ b/Mage.CLI/Resources/DB/setup.sqlite.sql
@@ -46,7 +46,7 @@ create table image_metadata (
 create table audio_metadata (
     document_id     integer not null primary key,
 
-    length          integer not null, -- seconds
+    duration        integer not null, -- seconds
 
     foreign key (document_id) references document(id)
 );
@@ -57,7 +57,7 @@ create table video_metadata (
 
     width           integer not null,
     height          integer not null,
-    length          integer not null, -- seconds
+    duration        integer not null, -- seconds
 
     foreign key (document_id) references document(id)
 );

--- a/Mage.CLI/Resources/DB/setup.sqlite.sql
+++ b/Mage.CLI/Resources/DB/setup.sqlite.sql
@@ -9,6 +9,13 @@ create table document (
     file_name       text not null,
     file_ext        text not null,
     file_size       integer not null, -- bytes
+    media_type      text check(media_type in ('b', 't', 'i', 'm', 'a', 'v')) not null default 'b',
+                    -- b = binary
+                    -- t = text
+                    -- i = image
+                    -- m = animation
+                    -- a = audio
+                    -- v = video
     added_at        integer not null default (unixepoch()), -- unix timestamp
     updated_at      integer not null default (unixepoch()), -- unix timestamp
     comment         text,
@@ -24,6 +31,36 @@ create view deleted_document as
     select * 
     from document 
     where is_deleted = 1;
+
+-- document.media_type = 'i'
+create table document_st_image (
+    document_id     integer not null primary key,
+
+    width           integer not null,
+    height          integer not null,
+
+    foreign key (document_id) references document(id)
+);
+
+-- document.media_type = 'a'
+create table document_st_audio (
+    document_id     integer not null primary key,
+
+    length          integer not null, -- seconds
+
+    foreign key (document_id) references document(id)
+);
+
+-- document.media_type = 'm' or 'v'
+create table document_st_video (
+    document_id     integer not null primary key,
+
+    width           integer not null,
+    height          integer not null,
+    length          integer not null, -- seconds
+
+    foreign key (document_id) references document(id)
+);
 
 ---
 --- TAXONYMS

--- a/Mage.CLI/Resources/DB/setup.sqlite.sql
+++ b/Mage.CLI/Resources/DB/setup.sqlite.sql
@@ -33,7 +33,7 @@ create view deleted_document as
     where is_deleted = 1;
 
 -- document.media_type = 'i'
-create table document_st_image (
+create table image_metadata (
     document_id     integer not null primary key,
 
     width           integer not null,
@@ -43,7 +43,7 @@ create table document_st_image (
 );
 
 -- document.media_type = 'a'
-create table document_st_audio (
+create table audio_metadata (
     document_id     integer not null primary key,
 
     length          integer not null, -- seconds
@@ -52,7 +52,7 @@ create table document_st_audio (
 );
 
 -- document.media_type = 'm' or 'v'
-create table document_st_video (
+create table video_metadata (
     document_id     integer not null primary key,
 
     width           integer not null,


### PR DESCRIPTION
Mage can now determine the type of media represented by a file and store metadata related to its content. This metadata is stored in tables correlated with the `document` table, and discriminated by the new single-char `media_type` column.

The media types at present are:

- Binary (b)
- Text (t)
- Image (i)
- Animation (m)
- Audio (a)
- Video (v)

### Example
```
document [...]
  Archive ID: /19
  File name: [...]
  File extension: gif
  File size: 1 MB
  Added at: 5/24/2024 3:07:25 PM
  Updated at: 5/24/2024 3:07:25 PM
  Media type: animation
    Animation dimension: 811x1014
    Animation duration: 750 ms
  Deleted: no
  Comment: <none>
  Tags: <none>
  Sources: <none>
```

Resolves #48 
