### PR TITLE
Media metatags

### DIFF
--- a/Mage.CLI/Engine/Archive.cs
+++ b/Mage.CLI/Engine/Archive.cs
@@ -122,7 +122,7 @@ public class Archive {
     public static readonly SemanticVersion VERSION = new SemanticVersion(){
         releaseType = -1,
         major = 11,
-        minor = 0,
+        minor = 1,
         patch = 0
     };
 

--- a/Mage.CLI/Engine/Query/QueryEngine.cs
+++ b/Mage.CLI/Engine/Query/QueryEngine.cs
@@ -53,9 +53,15 @@ public static class QueryParser {
             Sprache.Parse.String("id").Text()
             .Or(Sprache.Parse.String("hash").Text())
             .Or(Sprache.Parse.String("file_name").Text())
-            .Or(Sprache.Parse.String("extension").Text())
-            .Or(Sprache.Parse.String("ingested_at").Text())
+            .Or(Sprache.Parse.String("file_ext").Text())
+            .Or(Sprache.Parse.String("added_at").Text())
+            .Or(Sprache.Parse.String("updated_at").Text())
             .Or(Sprache.Parse.String("comment").Text())
+            .Or(Sprache.Parse.String("media_type").Text())
+            
+            .Or(Sprache.Parse.String("width").Text())
+            .Or(Sprache.Parse.String("height").Text())
+            .Or(Sprache.Parse.String("duration").Text())
         from lparen in Sprache.Parse.Char('(')
         from op in Sprache.Parse.Optional(
             Sprache.Parse.String("=").Text()


### PR DESCRIPTION
Media-specific metadata such as image width and video duration can now be queried.

```bash
mage search "width(<256) height(<256)"
```

```bash
mage search "media_type('v')" # find all videos
mage search "media_type('m')" # find all animated images
```

Resolves #61 