### PR TITLE
Migration framework

### DIFF
--- a/Mage.CLI/CLI/Program.cs
+++ b/Mage.CLI/CLI/Program.cs
@@ -22,8 +22,15 @@ try {
     }
 } catch(Archive.IncompatibleArchiveException ex){
     ConsoleExt.WriteColored("ERROR: ", ConsoleColor.Red);
-    Console.WriteLine(ex);
-    return;
+    Console.WriteLine("Incompatible archive version. Attempting to migrate...");
+
+    var success = Migration.Migrate(ctx.archiveDir);
+    
+    if(success){
+        ctx.archive = Archive.Load(ctx.archiveDir);
+    } else {
+        return;
+    }
 }
 
 var rootCommand = CLICommands.CreateRoot(ctx);

--- a/Mage.CLI/Engine/Migration.cs
+++ b/Mage.CLI/Engine/Migration.cs
@@ -7,10 +7,6 @@ public class Migration {
     /// <summary>Please order by version.</summary>
     public static List<(SemanticVersion version, Func<string, bool> migrate)> MigrationScripts = [
         
-        (SemanticVersion.FromString("alpha_12.0.0"), (archiveDir) => {
-            return true;
-        })
-
     ];
 
     public static bool Migrate(string archiveDir){

--- a/Mage.CLI/Engine/Migration.cs
+++ b/Mage.CLI/Engine/Migration.cs
@@ -1,0 +1,68 @@
+using Mage.CLI;
+
+namespace Mage.Engine;
+
+public class Migration {
+
+    /// <summary>Please order by version.</summary>
+    public static List<(SemanticVersion version, Func<string, bool> migrate)> MigrationScripts = [
+        
+        (SemanticVersion.FromString("alpha_12.0.0"), (archiveDir) => {
+            return true;
+        })
+
+    ];
+
+    public static bool Migrate(string archiveDir){
+
+        var infoMap = Archive.ReadInfoFile(archiveDir);
+
+        string versionStr = infoMap["version"];
+
+        var archiveVersion = SemanticVersion.FromString(versionStr).Normalise();
+        var buildVersion = Archive.VERSION.Normalise();
+
+        if(archiveVersion > buildVersion){
+            ConsoleExt.WriteColored("ERROR: ", ConsoleColor.Red);
+                Console.WriteLine($"Archive was made in a newer version: {archiveVersion}");
+            return false;
+        }
+
+        var failure = false;
+
+        for(int i = 0; i < MigrationScripts.Count(); i++){
+            var nextVersion = MigrationScripts[i].version;
+
+            // versions predating the archive
+            if(nextVersion <= archiveVersion)
+                continue;
+
+            // versions predating the build (edge case)
+            if(nextVersion > buildVersion)
+                break;
+            
+            var success = MigrationScripts[i].migrate(archiveDir);
+
+            if(success){
+                ConsoleExt.WriteColored("SUCCESS: ", ConsoleColor.Green);
+                Console.WriteLine($"Migrated from {archiveVersion} to {nextVersion}.");
+                archiveVersion = nextVersion;
+
+                infoMap["version"] = archiveVersion.ToString();
+                Archive.WriteInfoFile(archiveDir, infoMap);
+            } else {
+                ConsoleExt.WriteColored("ERROR: ", ConsoleColor.Red);
+                Console.WriteLine($"Unable to migrate from {archiveVersion} to {nextVersion}. (Script failed.)");
+                failure = true;
+            }
+        }
+
+        if(!failure && archiveVersion.Normalise() < buildVersion.Normalise()){
+            ConsoleExt.WriteColored("ERROR: ", ConsoleColor.Red);
+            Console.WriteLine($"Unable to migrate from {archiveVersion} to {buildVersion}. (No script.)");
+        }
+
+        return archiveVersion == buildVersion;
+    }
+
+}

--- a/Mage.CLI/Engine/Migration.cs
+++ b/Mage.CLI/Engine/Migration.cs
@@ -62,6 +62,11 @@ public class Migration {
             Console.WriteLine($"Unable to migrate from {archiveVersion} to {buildVersion}. (No script.)");
         }
 
+        if(archiveVersion == buildVersion){
+            infoMap["version"] = Archive.VERSION.ToString();
+            Archive.WriteInfoFile(archiveDir, infoMap);
+        }        
+
         return archiveVersion == buildVersion;
     }
 


### PR DESCRIPTION
If an incompatible archive version exception occurs while loading an archive, the tool will attempt to migrate the archive with a sequence of pre-defined scripts, which each migrate from one major version to the next.

No migration scripts are currently implemented, but future major releases should do so. Unfortunately, there are few tools available to make this simple, and so it may be necessary to write subpar code to achieve migration, such as by using ad-hoc parsers and so on.

Further thought:
- How should the database be migrated? A naive idea is to create new tables under names like `_migrate_document`, according to the new schema, copy all rows and impute missing values where possible, then delete the old tables and rename the new tables.

Resolves #3 