### PR TITLE
Query result order

### DIFF
--- a/Mage.CLI/CLI/Main.cs
+++ b/Mage.CLI/CLI/Main.cs
@@ -70,10 +70,10 @@ public static partial class CLICommands {
         var com = new Command("test", "For debugging purposes.");
         com.SetHandler(() => {
             
-            var query = QueryParser.Query.Parse("(rose_lalonde AND dirk_strider) OR homestuck2");
+            /*var query = QueryParser.Query.Parse("(rose_lalonde AND dirk_strider) OR homestuck2");
             Console.WriteLine(query.root);
 
-            query.GetResults(ctx.archive);
+            query.GetResults(ctx.archive);*/
 
         });
 

--- a/Mage.CLI/Engine/Archive.cs
+++ b/Mage.CLI/Engine/Archive.cs
@@ -165,8 +165,8 @@ public class Archive {
     public static readonly SemanticVersion VERSION = new SemanticVersion(){
         releaseType = -1,
         major = 12,
-        minor = 0,
-        patch = 1
+        minor = 1,
+        patch = 0
     };
 
     public const string IN_VIEW_NAME = "in";

--- a/Mage.CLI/Engine/DB/DBCommands.cs
+++ b/Mage.CLI/Engine/DB/DBCommands.cs
@@ -34,8 +34,7 @@ public static class DBCommands {
         ";
         public const string DocumentRankingWhereName = @"
             select 
-                document_ranking_full.id, 
-                document_ranking_full.ranking_name, 
+                document_ranking_full.id,
                 ifnull(score, 0) score
             from
                 (document cross join 


### PR DESCRIPTION
The results of a query can now be ordered by document ID or by document ranking, in either ascending or descending order.

```bash
mage search "rose_lalonde" --order rank:sexy --desc
```

Resolves #26 