### PR TITLE
Keep one document fixed in ranking tournament

### DIFF
--- a/Mage.CLI/CLI/Rankings.cs
+++ b/Mage.CLI/CLI/Rankings.cs
@@ -23,15 +23,19 @@ public static partial class CLICommands {
     }
 
     public static Command ComRankingsTournament(CLIContext ctx){
-        var com = new Command("tournament", "Run a rankings tournament.");
 
-        com.SetHandler(() => {
+        var singleOption = new Option<string?>(
+            name: "--single",
+            description: "Match opponents against single selected document.",
+            getDefaultValue: () => null
+        );
+
+        var com = new Command("tournament", "Run a rankings tournament."){
+            singleOption
+        };
+
+        com.SetHandler((docRef) => {
             ctx.archive.db.EnsureConnected();
-
-            using var docSampleCom = ctx.archive.db.GenCommand(
-                DBCommands.Sample.Document(),
-                ("limit", 2)
-            );
 
             using var rankingSampleCom = ctx.archive.db.GenCommand(
                 DBCommands.Sample.Ranking,
@@ -40,10 +44,36 @@ public static partial class CLICommands {
 
             ctx.archive.ViewCreate("tournament");
 
+            using var docSampleCom = ctx.archive.db.GenCommand(
+                DBCommands.Sample.Document(),
+                ("limit", null)
+            );
+
+            DocumentID? docA = null;
+            
+            if(docRef is null){
+                docSampleCom.Parameters["limit"].Value = 2;
+            } else {
+                docSampleCom.Parameters["limit"].Value = 1;
+                docA = (DocumentID)ObjectRef.ResolveDocument(ctx.archive, docRef)!;
+            }
+
             while(true){
-                var docSample = DBEngine.RunQuery(docSampleCom, r => (DocumentID)r.GetInt32(0)).ToArray();
-                if(docSample.Count() != 2){
-                    return;
+
+                DocumentID? docB = null;
+                
+                if(docRef is null){
+                    var docSample = DBEngine.RunQuery(docSampleCom, r => (DocumentID)r.GetInt32(0)).ToArray();
+                    if(docSample.Count() != 2){
+                        return;
+                    }
+
+                    docA = docSample[0];
+                    docB = docSample[1];
+                } else {
+                    while(docB is null || docB == docA){
+                        docB = DBEngine.RunQuerySingle(docSampleCom, r => (DocumentID)r.GetInt32(0));
+                    }
                 }
 
                 var rankingSample = DBEngine.RunQuery(rankingSampleCom, r => r.GetString(0)).ToArray();
@@ -51,18 +81,16 @@ public static partial class CLICommands {
                     return;
                 }
 
-                var docA = docSample[0];
-                var docB = docSample[1];
                 var ranking = rankingSample[0];
                 
-                var docARanking = ctx.archive.DocumentGetRanking(docA, ranking);
-                var docBRanking = ctx.archive.DocumentGetRanking(docB, ranking);
+                var docARanking = ctx.archive.DocumentGetRanking((DocumentID)docA, ranking);
+                var docBRanking = ctx.archive.DocumentGetRanking((DocumentID)docB, ranking);
                 var docAScore = 0;
                 var docBScore = 0;
 
                 ctx.archive.ViewClear("tournament");
-                ctx.archive.ViewAdd("tournament", docA);
-                ctx.archive.ViewAdd("tournament", docB);
+                ctx.archive.ViewAdd("tournament", (DocumentID)docA);
+                ctx.archive.ViewAdd("tournament", (DocumentID)docB);
 
                 Console.WriteLine($"Which is more '{ranking}': tournament/0 (a), tournament/1 (b), or neither (n)? (q to quit)");
                 Console.Write("> ");
@@ -78,18 +106,18 @@ public static partial class CLICommands {
                     docAScore = 0;
                     docBScore = 0;
                 } else if(lineIn == "q"){
-                    break;;
+                    break;
                 }
 
                 var docAUpdatedRanking = Elo.Update(docARanking, docBRanking, docAScore);
                 var docBUpdatedRanking = Elo.Update(docBRanking, docARanking, docBScore);
 
-                ctx.archive.DocumentSetRanking(docA, ranking, docAUpdatedRanking);
-                ctx.archive.DocumentSetRanking(docB, ranking, docBUpdatedRanking);
+                ctx.archive.DocumentSetRanking((DocumentID)docA, ranking, docAUpdatedRanking);
+                ctx.archive.DocumentSetRanking((DocumentID)docB, ranking, docBUpdatedRanking);
             }
 
             ctx.archive.ViewDelete("tournament");
-        });
+        }, singleOption);
 
         return com;
     }

--- a/Mage.CLI/Engine/Archive.cs
+++ b/Mage.CLI/Engine/Archive.cs
@@ -165,8 +165,8 @@ public class Archive {
     public static readonly SemanticVersion VERSION = new SemanticVersion(){
         releaseType = -1,
         major = 12,
-        minor = 1,
-        patch = 1
+        minor = 2,
+        patch = 0
     };
 
     public const string IN_VIEW_NAME = "in";

--- a/Mage.CLI/Engine/DB/DBEngine.cs
+++ b/Mage.CLI/Engine/DB/DBEngine.cs
@@ -67,9 +67,11 @@ public partial class DBEngine {
     }
 
     public static T? RunQuerySingle<T>(SqliteCommand com, Func<SqliteDataReader, T> read) {
-        var reader = com.ExecuteReader();
+        using var reader = com.ExecuteReader();
         if(reader.Read()){
-            return read(reader);
+            var res = read(reader);
+            reader.Close();
+            return res;
         }
         reader.Close();
         return default(T?);


### PR DESCRIPTION
By passing the `--single` option with a document reference, all tournament rounds will match a random document against this document, rather than both documents being random.

```bash
mage rankings tournament --single in/0
```