### PR TITLE
Single ranking tournament mode

### DIFF
--- a/Mage.CLI/Engine/Archive.cs
+++ b/Mage.CLI/Engine/Archive.cs
@@ -17,8 +17,8 @@ public class Archive {
     public static readonly SemanticVersion VERSION = new SemanticVersion(){
         releaseType = -1,
         major = 15,
-        minor = 0,
-        patch = 1
+        minor = 1,
+        patch = 0
     };
 
     public const string IN_DIR_PATH = "in/";


### PR DESCRIPTION
The single document tournament mode has been removed and replaced with the more statistically-sound single ranking tournament mode, in which documents are only matched w/r/t the ranking of the user's choosing.

Resolves #79 