### PR TITLE
Document comment command

### DIFF
--- a/Mage.CLI/CLI/Doc.cs
+++ b/Mage.CLI/CLI/Doc.cs
@@ -29,7 +29,8 @@ public static partial class CLICommands {
             ComDocUntag(ctx, docRefArgument),
             ComDocSources(ctx, docRefArgument),
             ComDocSource(ctx, docRefArgument),
-            ComDocUnsource(ctx, docRefArgument)
+            ComDocUnsource(ctx, docRefArgument),
+            ComDocComment(ctx, docRefArgument)
         };
 
         com.SetHandler((docRef, reflect) => {
@@ -175,6 +176,38 @@ public static partial class CLICommands {
             }
 
         }, docRefArgument);
+
+        return com;
+    }
+
+    public static Command ComDocComment(CLIContext ctx, Argument<string> docRefArgument){
+        var commentArgument = new Argument<string?>(
+            name: "comment",
+            getDefaultValue: () => null
+        );
+
+        var com = new Command("comment", "Modify comment on document."){
+            commentArgument
+        };
+
+        com.SetHandler((docRef, comment) => {
+            var docID = (DocumentID)ObjectRef.ResolveDocument(ctx.archive, docRef)!;
+
+            if(comment is null){
+                var doc = (Document)ctx.archive.DocumentGet(docID)!;
+                
+                ctx.archive.SetCommentFile(doc.comment);
+                Console.WriteLine("Edit data/comment.txt and then press enter to set the comment.");
+                
+                Process.Start("notepad.exe", $"{ctx.archive.archiveDir}{Archive.COMMENT_FILE_PATH}");
+
+                Console.Read();
+                comment = ctx.archive.ReadCommentFile();
+            }
+
+            ctx.archive.DocumentSetComment(docID, comment);
+
+        }, docRefArgument, commentArgument);
 
         return com;
     }

--- a/Mage.CLI/Engine/Archive.cs
+++ b/Mage.CLI/Engine/Archive.cs
@@ -74,6 +74,9 @@ public class Archive {
     }
 
     public string? ReadCommentFile(){
+        if(!File.Exists($"{archiveDir}{COMMENT_FILE_PATH}")){
+            File.Create($"{archiveDir}{COMMENT_FILE_PATH}");
+        }
         var comment = File.ReadAllText($"{archiveDir}{COMMENT_FILE_PATH}");
         if(comment == "") return null;
         else return comment;

--- a/Mage.CLI/Engine/Archive.cs
+++ b/Mage.CLI/Engine/Archive.cs
@@ -30,6 +30,7 @@ public class Archive {
     public const string BIND_FILE_PATH = DATA_DIR_PATH + "bind.ini";
     public const string DB_FILE_PATH = DATA_DIR_PATH + "db.sqlite";
     public const string INGEST_LIST_FILE_PATH = DATA_DIR_PATH + "ingestlist.txt";
+    public const string COMMENT_FILE_PATH = DATA_DIR_PATH + "comment.txt";
 
     public const string INGEST_LIST_FILE_HEADER = "# file path | comment | tag list | series | source list\n";
 
@@ -68,6 +69,16 @@ public class Archive {
         return infoMap;
     }
 
+    public void SetCommentFile(string? comment){
+        File.WriteAllText($"{archiveDir}{COMMENT_FILE_PATH}", comment ?? "");
+    }
+
+    public string? ReadCommentFile(){
+        var comment = File.ReadAllText($"{archiveDir}{COMMENT_FILE_PATH}");
+        if(comment == "") return null;
+        else return comment;
+    }
+
     public static Archive Init(string archiveDir, string? name = null){
         var fileDir = archiveDir;
 
@@ -95,8 +106,9 @@ public class Archive {
             $"view={DEFAULT_VIEW_NAME}"
         ]);
 
-        // create ingest list file
+        // create other files
         File.WriteAllText($"{archiveDir}{INGEST_LIST_FILE_PATH}", INGEST_LIST_FILE_HEADER);
+        File.Create($"{archiveDir}{COMMENT_FILE_PATH}");
 
         var archive = Load(archiveDir);
         
@@ -463,6 +475,11 @@ public class Archive {
     public void DocumentSetRating(DocumentID documentID, string rankingName, int score){
         db.EnsureConnected();
         db.UpdateDocumentRating(documentID, rankingName, score);
+    }
+
+    public void DocumentSetComment(DocumentID documentID, string? comment){
+        db.EnsureConnected();
+        db.UpdateDocumentComment(documentID, comment);
     }
 
     public Taxonym? TaxonymGet(TaxonymID taxonymID){

--- a/Mage.CLI/Engine/DB/DBCommands.cs
+++ b/Mage.CLI/Engine/DB/DBCommands.cs
@@ -128,7 +128,8 @@ public static class DBCommands {
         public const string DocumentIsDeletedWhereID = "update document set is_deleted = @is_deleted where id = @id";
         public const string DocumentUpdatedAt = "update document set updated_at = unixepoch()";
         public const string DocumentUpdatedAtWhereID = "update document set updated_at = unixepoch() where id = @id";
-        
+        public const string DocumentCommentWhereID = "update document set comment = @comment where id = @id";
+
         public const string DocumentRating = "insert or replace into document_rating (document_id, ranking_name, rating) values (@document_id, @ranking_name, @rating)"; 
         
     }

--- a/Mage.CLI/Engine/DB/DBEngine.cs
+++ b/Mage.CLI/Engine/DB/DBEngine.cs
@@ -3,6 +3,7 @@ using System.Data;
 using System.Data.SqlTypes;
 using System.Diagnostics;
 using System.Resources;
+using System.Transactions;
 using Microsoft.Data.Sqlite;
 using SQLitePCL;
 
@@ -773,6 +774,18 @@ public partial class DBEngine {
 
 // Update
 public partial class DBEngine {
+
+    public void UpdateDocumentComment(DocumentID documentID, string? comment, SqliteTransaction? transaction = null){
+        using var com = GenCommand(
+            DBCommands.Update.DocumentCommentWhereID,
+            ("id", documentID),
+            ("comment", comment)
+        );
+        com.Transaction = transaction;
+        RunNonQuery(com);
+
+        UpdateDocumentUpdatedAt(documentID);
+    }
 
     public void UpdateDocumentIsDeleted(DocumentID documentID, bool isDeleted, SqliteTransaction? transaction = null){
         using var com = GenCommand(


### PR DESCRIPTION
Document comments can now be added or modified.

Set the comment directly:
```
mage doc main/0 comment "test comment"
```

Edit the comment in `data/comment.txt`:
```
mage doc main/0 comment
```

Resolves #57 