### PR TITLE
Improve metatag syntax

### DIFF
--- a/Mage.CLI/Engine/Archive.cs
+++ b/Mage.CLI/Engine/Archive.cs
@@ -17,7 +17,7 @@ public class Archive {
     public static readonly SemanticVersion VERSION = new SemanticVersion(){
         releaseType = -1,
         major = 15,
-        minor = 5,
+        minor = 6,
         patch = 0
     };
 

--- a/Mage.CLI/Engine/Query/QueryEngine.cs
+++ b/Mage.CLI/Engine/Query/QueryEngine.cs
@@ -62,7 +62,7 @@ public static class QueryParser {
             .Or(Sprache.Parse.String("width").Text())
             .Or(Sprache.Parse.String("height").Text())
             .Or(Sprache.Parse.String("duration").Text())
-        from lparen in Sprache.Parse.Char('(')
+        from colon in Sprache.Parse.Char(':')
         from op in Sprache.Parse.Optional(
             Sprache.Parse.String("=").Text()
             .Or(Sprache.Parse.String("!=").Text())
@@ -71,11 +71,10 @@ public static class QueryParser {
             .Or(Sprache.Parse.String("<").Text())
             .Or(Sprache.Parse.String("<=").Text())
             .Or(Sprache.Parse.String("like").Text())
-        ).Token()
+        )
         from param in 
-            Sprache.Parse.Numeric.AtLeastOnce().Text().Token()
-            .Or(SingleQuotedString.Token())
-        from rparen in Sprache.Parse.Char(')')
+            Sprache.Parse.Numeric.AtLeastOnce().Text()
+            .Or(SingleQuotedString)
         select new QueryNodeMetaTag(){
             tag = tag,
             op = ParseParameterOperator(op.GetOrElse("")),

--- a/Mage.CLI/Engine/Query/QueryEngine.cs
+++ b/Mage.CLI/Engine/Query/QueryEngine.cs
@@ -43,7 +43,7 @@ public static class QueryParser {
             case ">=": return QueryParameterOperator.GreaterOrEquals; break;
             case "<": return QueryParameterOperator.Lesser; break;
             case "<=": return QueryParameterOperator.LesserOrEquals; break;
-            case "like": return QueryParameterOperator.Like; break;
+            case "~": return QueryParameterOperator.Like; break;
         }
         return QueryParameterOperator.Equals;
     }
@@ -70,7 +70,7 @@ public static class QueryParser {
             .Or(Sprache.Parse.String(">=").Text())
             .Or(Sprache.Parse.String("<").Text())
             .Or(Sprache.Parse.String("<=").Text())
-            .Or(Sprache.Parse.String("like").Text())
+            .Or(Sprache.Parse.String("~").Text())
         )
         from param in 
             Sprache.Parse.Numeric.AtLeastOnce().Text()


### PR DESCRIPTION
Metatags are now of the form `metatag:[op]param` rather than `metatag([op]param)`. Additionally, the `like` operator has been replaced with `~`.

Resolves #65 